### PR TITLE
Reorder tests dependency

### DIFF
--- a/tests/bool2d/test_bool_finite_intersect.py
+++ b/tests/bool2d/test_bool_finite_intersect.py
@@ -10,7 +10,7 @@ from shapepy.bool2d.shape import SimpleShape
 from shapepy.geometry.jordancurve import JordanCurve
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(32)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -19,6 +19,7 @@ from shapepy.geometry.jordancurve import JordanCurve
         "tests/bool2d/test_primitive.py::test_end",
         "tests/bool2d/test_contains.py::test_end",
         "tests/bool2d/test_empty_whole.py::test_end",
+        "tests/bool2d/test_bool_no_intersect.py::test_end",
     ],
     scope="session",
 )
@@ -32,12 +33,12 @@ class TestIntersectionSimple:
     of intersection points
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(32)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(32)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestIntersectionSimple::test_begin"])
     def test_or_two_rombos(self):
@@ -54,7 +55,7 @@ class TestIntersectionSimple:
         test_shape = square0 | square1
         assert test_shape == good_shape
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(32)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestIntersectionSimple::test_begin"])
     def test_and_two_rombos(self):
@@ -65,7 +66,7 @@ class TestIntersectionSimple:
         good = Primitive.regular_polygon(nsides=4, radius=1, center=(0, 0))
         assert test == good
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(32)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -87,7 +88,7 @@ class TestIntersectionSimple:
         assert square0 - square1 == left_shape
         assert square1 - square0 == right_shape
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(32)
     @pytest.mark.dependency(
         depends=[
             "TestIntersectionSimple::test_begin",
@@ -100,7 +101,7 @@ class TestIntersectionSimple:
         pass
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(32)
 @pytest.mark.dependency(
     depends=[
         "TestIntersectionSimple::test_end",

--- a/tests/bool2d/test_bool_infinite_intersect.py
+++ b/tests/bool2d/test_bool_infinite_intersect.py
@@ -7,7 +7,7 @@ import pytest
 from shapepy.bool2d.primitive import Primitive
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(33)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -16,6 +16,9 @@ from shapepy.bool2d.primitive import Primitive
         "tests/bool2d/test_primitive.py::test_end",
         "tests/bool2d/test_contains.py::test_end",
         "tests/bool2d/test_empty_whole.py::test_end",
+        "tests/bool2d/test_shape.py::test_end",
+        "tests/bool2d/test_bool_no_intersect.py::test_end",
+        "tests/bool2d/test_bool_finite_intersect.py::test_end",
     ],
     scope="session",
 )
@@ -24,7 +27,7 @@ def test_begin():
 
 
 class TestTriangle:
-    @pytest.mark.order(9)
+    @pytest.mark.order(33)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -33,7 +36,7 @@ class TestTriangle:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(33)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTriangle::test_begin"])
     def test_or_triangles(self):
@@ -47,7 +50,7 @@ class TestTriangle:
         good = Primitive.polygon(vertices)
         assert test == good
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(33)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -66,7 +69,7 @@ class TestTriangle:
         good = Primitive.polygon(vertices)
         assert test == good
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(33)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -87,7 +90,7 @@ class TestTriangle:
 
         assert test == good
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(33)
     @pytest.mark.dependency(
         depends=[
             "TestTriangle::test_begin",
@@ -100,7 +103,7 @@ class TestTriangle:
         pass
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(33)
 @pytest.mark.dependency(
     depends=[
         "TestTriangle::test_end",

--- a/tests/bool2d/test_bool_no_intersect.py
+++ b/tests/bool2d/test_bool_no_intersect.py
@@ -14,7 +14,7 @@ from shapepy.bool2d.shape import (
 )
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(31)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -35,12 +35,12 @@ class TestEqualSquare:
     Make tests of boolean operations between the same shape (a square)
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestEqualSquare::test_begin"])
     def test_or(self):
@@ -51,7 +51,7 @@ class TestEqualSquare:
         assert (~square) | square is WholeShape()
         assert (~square) | (~square) == ~square
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=["TestEqualSquare::test_begin", "TestEqualSquare::test_or"]
@@ -64,7 +64,7 @@ class TestEqualSquare:
         assert (~square) & square is EmptyShape()
         assert (~square) & (~square) == ~square
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -80,7 +80,7 @@ class TestEqualSquare:
         assert (~square) - square == ~square
         assert (~square) - (~square) is EmptyShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -98,7 +98,7 @@ class TestEqualSquare:
         assert (~square) ^ square is WholeShape()
         assert (~square) ^ (~square) is EmptyShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "TestEqualSquare::test_begin",
@@ -120,14 +120,14 @@ class TestTwoCenteredSquares:
     which is tested in other file
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=["test_begin", "TestEqualSquare::test_end"]
     )
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoCenteredSquares::test_begin"])
     def test_or(self):
@@ -145,7 +145,7 @@ class TestTwoCenteredSquares:
         assert (~square1) | (~square2) == ~square1
         assert (~square2) | (~square1) == ~square1
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoCenteredSquares::test_begin"])
     def test_and(self):
@@ -163,7 +163,7 @@ class TestTwoCenteredSquares:
         assert (~square1) & (~square2) == ~square2
         assert (~square2) & (~square1) == ~square2
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoCenteredSquares::test_begin"])
     def test_sub(self):
@@ -181,7 +181,7 @@ class TestTwoCenteredSquares:
         assert (~square1) - (~square2) == ConnectedShape([square2, ~square1])
         assert (~square2) - (~square1) is EmptyShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoCenteredSquares::test_begin"])
     def test_xor(self):
@@ -199,7 +199,7 @@ class TestTwoCenteredSquares:
         assert (~square1) ^ (~square2) == ConnectedShape([square2, ~square1])
         assert (~square2) ^ (~square1) == ConnectedShape([square2, ~square1])
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "TestTwoCenteredSquares::test_begin",
@@ -221,7 +221,7 @@ class TestTwoDisjointSquares:
     which is tested in other file
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -231,7 +231,7 @@ class TestTwoDisjointSquares:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjointSquares::test_begin"])
     def test_or(self):
@@ -249,7 +249,7 @@ class TestTwoDisjointSquares:
         assert (~left) | (~right) is WholeShape()
         assert (~right) | (~left) is WholeShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjointSquares::test_begin"])
     def test_and(self):
@@ -267,7 +267,7 @@ class TestTwoDisjointSquares:
         assert (~left) & (~right) == ConnectedShape([~left, ~right])
         assert (~right) & (~left) == ConnectedShape([~left, ~right])
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjointSquares::test_begin"])
     def test_sub(self):
@@ -285,7 +285,7 @@ class TestTwoDisjointSquares:
         assert (~left) - (~right) == right
         assert (~right) - (~left) == left
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjointSquares::test_begin"])
     def test_xor(self):
@@ -303,7 +303,7 @@ class TestTwoDisjointSquares:
         assert (~left) ^ (~right) == DisjointShape([left, right])
         assert (~right) ^ (~left) == DisjointShape([left, right])
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "TestTwoDisjointSquares::test_begin",
@@ -322,12 +322,12 @@ class TestEqualHollowSquare:
     Make tests of boolean operations between the same shape (a square)
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestEqualHollowSquare::test_begin"])
     def test_or(self):
@@ -340,7 +340,7 @@ class TestEqualHollowSquare:
         assert (~square) | square is WholeShape()
         assert (~square) | (~square) == ~square
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -358,7 +358,7 @@ class TestEqualHollowSquare:
         assert (~square) & square is EmptyShape()
         assert (~square) & (~square) == ~square
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -376,7 +376,7 @@ class TestEqualHollowSquare:
         assert (~square) - square == ~square
         assert (~square) - (~square) is EmptyShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(
         depends=[
@@ -396,7 +396,7 @@ class TestEqualHollowSquare:
         assert (~square) ^ square is WholeShape()
         assert (~square) ^ (~square) is EmptyShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "TestEqualHollowSquare::test_begin",
@@ -418,7 +418,7 @@ class TestTwoDisjHollowSquares:
     which is tested in other file
     """
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -431,7 +431,7 @@ class TestTwoDisjHollowSquares:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjHollowSquares::test_begin"])
     def test_or(self):
@@ -453,7 +453,7 @@ class TestTwoDisjHollowSquares:
         assert (~left) | (~right) is WholeShape()
         assert (~right) | (~left) is WholeShape()
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjHollowSquares::test_begin"])
     def test_and(self):
@@ -477,7 +477,7 @@ class TestTwoDisjHollowSquares:
         assert (~left) & (~right) == good
         assert (~right) & (~left) == good
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjHollowSquares::test_begin"])
     def test_sub(self):
@@ -501,7 +501,7 @@ class TestTwoDisjHollowSquares:
         assert (~left) - (~right) == right
         assert (~right) - (~left) == left
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestTwoDisjHollowSquares::test_begin"])
     def test_xor(self):
@@ -525,7 +525,7 @@ class TestTwoDisjHollowSquares:
         assert (~left) ^ (~right) == DisjointShape([left, right])
         assert (~right) ^ (~left) == DisjointShape([left, right])
 
-    @pytest.mark.order(9)
+    @pytest.mark.order(31)
     @pytest.mark.dependency(
         depends=[
             "TestTwoDisjHollowSquares::test_begin",
@@ -539,7 +539,7 @@ class TestTwoDisjHollowSquares:
         pass
 
 
-@pytest.mark.order(9)
+@pytest.mark.order(31)
 @pytest.mark.dependency(
     depends=[
         "TestEqualSquare::test_end",

--- a/tests/bool2d/test_contains.py
+++ b/tests/bool2d/test_contains.py
@@ -18,7 +18,7 @@ from shapepy.bool2d.shape import (
 from shapepy.geometry.jordancurve import JordanCurve
 
 
-@pytest.mark.order(7)
+@pytest.mark.order(23)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -37,12 +37,12 @@ class TestObjectsInEmptyWhole:
     Test relative to special cases, a empty shape and whole domain
     """
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInEmptyWhole::test_begin"])
     def test_singleton(self):
         empty0 = EmptyShape()
@@ -55,7 +55,7 @@ class TestObjectsInEmptyWhole:
         assert whole0 is whole1
         assert empty1 != whole1
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -68,7 +68,7 @@ class TestObjectsInEmptyWhole:
         assert empty in empty
         assert empty in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -81,7 +81,7 @@ class TestObjectsInEmptyWhole:
         assert whole not in empty
         assert whole in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -95,7 +95,7 @@ class TestObjectsInEmptyWhole:
             assert point not in empty
             assert point in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -116,7 +116,7 @@ class TestObjectsInEmptyWhole:
         assert jordan not in empty
         assert jordan in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -131,7 +131,7 @@ class TestObjectsInEmptyWhole:
         assert shape not in empty
         assert shape in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -148,7 +148,7 @@ class TestObjectsInEmptyWhole:
         assert shape not in empty
         assert shape in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -165,7 +165,7 @@ class TestObjectsInEmptyWhole:
         assert shape not in empty
         assert shape in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInEmptyWhole::test_begin",
@@ -188,14 +188,14 @@ class TestObjectsInJordan:
     Tests the respective position
     """
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=["test_begin", "TestObjectsInEmptyWhole::test_end"]
     )
     def test_begin(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -224,7 +224,7 @@ class TestObjectsInJordan:
         assert (0.5, 1) in square
         assert (0, 0.5) in square
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -241,7 +241,7 @@ class TestObjectsInJordan:
         square = JordanCurve.from_vertices(vertices)
         assert (1, 1) not in square
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -258,7 +258,7 @@ class TestObjectsInJordan:
         assert (-1, -1) not in square
         assert (2, 2) not in square
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -277,7 +277,7 @@ class TestObjectsInSimple:
     Tests the respective position
     """
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -288,7 +288,7 @@ class TestObjectsInSimple:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInSimple::test_begin"])
     def test_empty(self):
         empty = EmptyShape()
@@ -296,7 +296,7 @@ class TestObjectsInSimple:
         assert empty in square
         assert square not in empty
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInSimple::test_begin"])
     def test_whole(self):
         whole = WholeShape()
@@ -304,7 +304,7 @@ class TestObjectsInSimple:
         assert whole not in square
         assert square in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -325,7 +325,7 @@ class TestObjectsInSimple:
             assert len(test_ids) == len(good_ids)
             assert test_ids == good_ids
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -350,7 +350,7 @@ class TestObjectsInSimple:
             assert len(test_types) == len(good_types)
             assert test_types == good_types
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -384,7 +384,7 @@ class TestObjectsInSimple:
         assert (3, 3) not in square
         assert (-3, -3) not in square
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -419,7 +419,7 @@ class TestObjectsInSimple:
         assert ~(big_square.jordans[0]) in (~small_square)
         assert ~(big_square.jordans[0]) in (~big_square)
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -456,7 +456,7 @@ class TestObjectsInSimple:
         assert (~left) not in (~right)
         assert (~right) not in (~left)
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -478,7 +478,7 @@ class TestObjectsInSimple:
         assert connected in (~small_square)
         assert connected not in (~big_square)
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -514,7 +514,7 @@ class TestObjectsInSimple:
         square = Primitive.square(side=7, center=(0, 0))
         assert disj_shape not in square
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInSimple::test_begin",
@@ -536,7 +536,7 @@ class TestObjectsInConnected:
     Tests the respective position
     """
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -548,7 +548,7 @@ class TestObjectsInConnected:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInConnected::test_begin"])
     def test_empty(self):
         empty = EmptyShape()
@@ -556,7 +556,7 @@ class TestObjectsInConnected:
         assert empty in square
         assert square not in empty
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInConnected::test_begin"])
     def test_whole(self):
         whole = WholeShape()
@@ -564,7 +564,7 @@ class TestObjectsInConnected:
         assert whole not in square
         assert square in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -598,7 +598,7 @@ class TestObjectsInConnected:
         assert (1.5, 1.5) in connected
         assert (1.5, -1.5) in connected
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -624,7 +624,7 @@ class TestObjectsInConnected:
         assert (~big_jordan) in connected
         assert (~big_jordan) in connected
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -644,7 +644,7 @@ class TestObjectsInConnected:
         assert (~small_square) not in connected
         assert (~big_square) not in connected
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -665,7 +665,7 @@ class TestObjectsInConnected:
         assert (~small_square) not in (~big_square)
         assert (~big_square) in (~big_square)
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -680,7 +680,7 @@ class TestObjectsInConnected:
     def test_disjoint(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInConnected::test_begin",
@@ -702,7 +702,7 @@ class TestObjectsInDisjoint:
     Tests the respective position
     """
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -715,7 +715,7 @@ class TestObjectsInDisjoint:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInDisjoint::test_begin"])
     def test_empty(self):
         empty = EmptyShape()
@@ -726,7 +726,7 @@ class TestObjectsInDisjoint:
         assert empty in disj_shape
         assert disj_shape not in empty
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(depends=["TestObjectsInDisjoint::test_begin"])
     def test_whole(self):
         whole = WholeShape()
@@ -737,7 +737,7 @@ class TestObjectsInDisjoint:
         assert whole not in disj_shape
         assert disj_shape in whole
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -755,7 +755,7 @@ class TestObjectsInDisjoint:
         assert (-3, 0) in disj_shape
         assert (3, 0) in disj_shape
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -767,7 +767,7 @@ class TestObjectsInDisjoint:
     def test_jordan(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -780,7 +780,7 @@ class TestObjectsInDisjoint:
     def test_simple(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -794,7 +794,7 @@ class TestObjectsInDisjoint:
     def test_connected(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -809,7 +809,7 @@ class TestObjectsInDisjoint:
     def test_disjoint(self):
         pass
 
-    @pytest.mark.order(7)
+    @pytest.mark.order(23)
     @pytest.mark.dependency(
         depends=[
             "TestObjectsInDisjoint::test_begin",
@@ -826,7 +826,7 @@ class TestObjectsInDisjoint:
         pass
 
 
-@pytest.mark.order(7)
+@pytest.mark.order(23)
 @pytest.mark.dependency(
     depends=[
         "TestObjectsInEmptyWhole::test_end",

--- a/tests/bool2d/test_empty_whole.py
+++ b/tests/bool2d/test_empty_whole.py
@@ -11,7 +11,7 @@ from shapepy.bool2d.primitive import Primitive
 from shapepy.bool2d.shape import EmptyShape, WholeShape
 
 
-@pytest.mark.order(8)
+@pytest.mark.order(24)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -31,12 +31,12 @@ class TestBoolean:
     Test boolean with special cases, a empty shape and whole domain
     """
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_or(self):
         empty = EmptyShape()
@@ -51,7 +51,7 @@ class TestBoolean:
         assert whole + empty is whole
         assert whole + whole is whole
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_and(self):
         empty = EmptyShape()
@@ -66,7 +66,7 @@ class TestBoolean:
         assert whole * empty is empty
         assert whole * whole is whole
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_xor(self):
         empty = EmptyShape()
@@ -76,7 +76,7 @@ class TestBoolean:
         assert whole ^ empty is whole
         assert whole ^ whole is empty
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_sub(self):
         empty = EmptyShape()
@@ -86,7 +86,7 @@ class TestBoolean:
         assert whole - empty is whole
         assert whole - whole is empty
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_bool(self):
         empty = EmptyShape()
@@ -94,7 +94,7 @@ class TestBoolean:
         assert bool(empty) is False
         assert bool(whole) is True
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_float(self):
         empty = EmptyShape()
@@ -102,7 +102,7 @@ class TestBoolean:
         assert float(empty) == float(0)
         assert float(whole) == float("inf")
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_invert(self):
         empty = EmptyShape()
@@ -112,7 +112,7 @@ class TestBoolean:
         assert ~(~empty) is empty
         assert ~(~whole) is whole
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_copy(self):
         empty = EmptyShape()
@@ -120,7 +120,7 @@ class TestBoolean:
         assert copy(empty) is empty
         assert copy(whole) is whole
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(
         depends=[
             "TestBoolean::test_begin",
@@ -139,7 +139,7 @@ class TestBoolean:
 
 
 class TestBoolShape:
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -149,6 +149,7 @@ class TestBoolShape:
     def test_begin(self):
         pass
 
+    @pytest.mark.order(24)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestBoolShape::test_begin"])
     def test_simple(self):
@@ -182,6 +183,7 @@ class TestBoolShape:
         assert empty - shape is empty
         assert whole - shape == ~shape
 
+    @pytest.mark.order(24)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestBoolShape::test_begin"])
     def test_connected(self):
@@ -217,12 +219,13 @@ class TestBoolShape:
         assert empty - shape is empty
         assert whole - shape == ~shape
 
+    @pytest.mark.order(24)
     @pytest.mark.timeout(40)
     @pytest.mark.dependency(depends=["TestBoolShape::test_begin"])
     def test_disjoint(self):
         pass
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(24)
     @pytest.mark.dependency(
         depends=[
             "TestBoolShape::test_begin",
@@ -235,9 +238,10 @@ class TestBoolShape:
         pass
 
 
-@pytest.mark.order(8)
+@pytest.mark.order(24)
 @pytest.mark.dependency(
     depends=[
+        "test_begin",
         "TestBoolean::test_end",
         "TestBoolShape::test_end",
     ]

--- a/tests/bool2d/test_primitive.py
+++ b/tests/bool2d/test_primitive.py
@@ -9,7 +9,7 @@ import pytest
 from shapepy import Primitive
 
 
-@pytest.mark.order(5)
+@pytest.mark.order(22)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -22,12 +22,12 @@ def test_begin():
 
 
 class TestPrimitive:
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestPrimitive::test_begin"])
     def test_creation(self):
@@ -57,7 +57,7 @@ class TestPrimitive:
         with pytest.raises(ValueError):
             Primitive.circle(radius="asd")
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=["TestPrimitive::test_begin", "TestPrimitive::test_creation"]
@@ -79,7 +79,7 @@ class TestPrimitive:
         area = 9
         assert abs(float(square) - area) < 1e-9
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -100,7 +100,7 @@ class TestPrimitive:
             area = radius**2 * nsides * math.sin(2 * math.pi / nsides) / 2
             assert abs(float(polygon) - area) < 1e-9
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -121,7 +121,7 @@ class TestPrimitive:
         area = -0.5
         assert abs(float(triangle) - area) < 1e-9
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -142,7 +142,7 @@ class TestPrimitive:
         area = math.pi * radius**2
         assert abs(float(circle) - area) < 1e-3 * radius**2
 
-    @pytest.mark.order(5)
+    @pytest.mark.order(22)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -158,7 +158,7 @@ class TestPrimitive:
         pass
 
 
-@pytest.mark.order(5)
+@pytest.mark.order(22)
 @pytest.mark.dependency(
     depends=[
         "TestPrimitive::test_end",

--- a/tests/bool2d/test_shape.py
+++ b/tests/bool2d/test_shape.py
@@ -12,7 +12,7 @@ from shapepy.bool2d.shape import IntegrateShape, SimpleShape
 from shapepy.geometry.jordancurve import JordanCurve
 
 
-@pytest.mark.order(8)
+@pytest.mark.order(25)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -29,12 +29,12 @@ def test_begin():
 
 
 class TestIntegrate:
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrate::test_begin"])
     def test_centered_rectangular(self):
@@ -54,7 +54,7 @@ class TestIntegrate:
                     good /= 2 ** (expx + expy)
                 assert abs(test - good) < 1e-9
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -81,7 +81,7 @@ class TestIntegrate:
                 good /= (1 + expx) * (1 + expy)
                 assert abs(test - good) < 1e-9 * abs(good)
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -107,7 +107,7 @@ class TestIntegrate:
                     good /= (1 + expx + expy) * (2 + expx + expy)
                 assert abs(test - good) < 1e-9
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -122,7 +122,7 @@ class TestIntegrate:
 
 
 class TestOthers:
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -131,7 +131,7 @@ class TestOthers:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.dependency(
         depends=[
             "TestOthers::test_begin",
@@ -144,7 +144,7 @@ class TestOthers:
         str(shape)
         repr(shape)
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.dependency(
         depends=[
             "TestOthers::test_begin",
@@ -157,7 +157,7 @@ class TestOthers:
         with pytest.raises(ValueError):
             shapea != 0
 
-    @pytest.mark.order(8)
+    @pytest.mark.order(25)
     @pytest.mark.dependency(
         depends=[
             "TestOthers::test_begin",
@@ -169,7 +169,7 @@ class TestOthers:
         pass
 
 
-@pytest.mark.order(8)
+@pytest.mark.order(25)
 @pytest.mark.dependency(
     depends=[
         "TestIntegrate::test_end",

--- a/tests/geometry/test_curve.py
+++ b/tests/geometry/test_curve.py
@@ -16,7 +16,7 @@ from shapepy.geometry.curve import (
 )
 
 
-@pytest.mark.order(3)
+@pytest.mark.order(12)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -28,12 +28,12 @@ def test_begin():
 
 
 class TestMath:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestMath::test_begin"])
     def test_comb(self):
@@ -55,7 +55,7 @@ class TestMath:
         assert Math.comb(4, 3) == 4
         assert Math.comb(4, 4) == 1
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestMath::test_begin"])
     def test_horner_method(self):
@@ -74,7 +74,7 @@ class TestMath:
         assert Math.horner_method(0.5, coefs) == 2.5
         assert Math.horner_method(1, coefs) == 3
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -99,7 +99,7 @@ class TestMath:
         good = [[-1, 3, -3, 1], [3, -6, 3, 0], [-3, 3, 0, 0], [1, 0, 0, 0]]
         np.testing.assert_allclose(test, good)
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -114,12 +114,12 @@ class TestMath:
 
 
 class TestScalarBezier:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestScalarBezier::test_begin"])
     def test_constant_one(self):
@@ -138,7 +138,7 @@ class TestScalarBezier:
         assert bezier(0.5) == 1
         assert bezier(1) == 1
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestScalarBezier::test_begin"])
     def test_constant_two(self):
@@ -158,7 +158,7 @@ class TestScalarBezier:
         assert bezier(0.5) == const
         assert bezier(1) == const
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestScalarBezier::test_begin"])
     def test_degree_1(self):
@@ -168,7 +168,7 @@ class TestScalarBezier:
         assert bezier(0.5) == 0.5 * (points[0] + points[1])
         assert bezier(1) == points[1]
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestScalarBezier::test_begin"])
     def test_degree_2(self):
@@ -179,7 +179,7 @@ class TestScalarBezier:
         assert abs(bezier(0.5) - good) < 1e-6
         assert abs(bezier(1) - points[2]) < 1e-6
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -195,19 +195,19 @@ class TestScalarBezier:
 
 
 class TestPlanarCurve:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestPlanarCurve::test_begin"])
     def test_construct(self):
         points = [(0, 0), (1, 0), (0, 1)]
         PlanarCurve(points)
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -220,7 +220,7 @@ class TestPlanarCurve:
 
 
 class TestDerivate:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -231,7 +231,7 @@ class TestDerivate:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestDerivate::test_begin"])
     def test_scalar_bezier(self):
@@ -240,7 +240,7 @@ class TestDerivate:
         dcurve = curve.derivate()
         assert id(dcurve) != id(curve)
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestDerivate::test_begin"])
     def test_planar_bezier(self):
@@ -249,7 +249,7 @@ class TestDerivate:
         dcurve = curve.derivate()
         assert id(dcurve) != id(curve)
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -263,12 +263,12 @@ class TestDerivate:
 
 
 class TestIntegrate:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrate::test_begin"])
     def test_lenght(self):
@@ -284,7 +284,7 @@ class TestIntegrate:
         curve = PlanarCurve(points)
         assert abs(IntegratePlanar.lenght(curve) - np.sqrt(2)) < 1e-9
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrate::test_begin"])
     def test_winding_triangles(self):
@@ -304,7 +304,7 @@ class TestIntegrate:
         wind = IntegratePlanar.winding_number(curve)
         assert abs(3 * wind - 1) < 1e-9
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -327,7 +327,7 @@ class TestIntegrate:
             maxim = max(maxim, diff)
             assert abs(good_wind - test_wind) < 1e-9
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -355,7 +355,7 @@ class TestIntegrate:
                 wind = IntegratePlanar.winding_number(curve)
                 assert abs(nsides * wind + 1) < 1e-2
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -371,12 +371,12 @@ class TestIntegrate:
 
 
 class TestOperations:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestOperations::test_begin"])
     def test_clean_segment(self):
@@ -395,7 +395,7 @@ class TestOperations:
         curve.clean(tolerance=None)
         assert curve.degree == 1
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -422,7 +422,7 @@ class TestOperations:
         curve.clean(tolerance=None)
         assert curve.degree == 1
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -436,12 +436,12 @@ class TestOperations:
 
 
 class TestContains:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestContains::test_begin"])
     def test_line(self):
@@ -471,7 +471,7 @@ class TestContains:
         assert (-1, -1) not in curve
         assert (-0.1, -0.1) not in curve
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -484,12 +484,12 @@ class TestContains:
 
 
 class TestSplitUnite:
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestSplitUnite::test_begin"])
     def test_middle(self):
@@ -503,7 +503,7 @@ class TestSplitUnite:
         test = curvea | curveb
         assert test == curve
 
-    @pytest.mark.order(3)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -515,7 +515,7 @@ class TestSplitUnite:
         pass
 
 
-@pytest.mark.order(3)
+@pytest.mark.order(12)
 @pytest.mark.dependency(
     depends=[
         "TestMath::test_end",

--- a/tests/geometry/test_jordan_curve.py
+++ b/tests/geometry/test_jordan_curve.py
@@ -13,7 +13,7 @@ from shapepy.geometry.point import Point2D
 from shapepy.scalar.reals import To
 
 
-@pytest.mark.order(6)
+@pytest.mark.order(14)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -27,12 +27,12 @@ def test_begin():
 
 
 class TestQuadraticJordan:
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestQuadraticJordan::test_begin"])
     def test_creation(self):
@@ -43,7 +43,7 @@ class TestQuadraticJordan:
         curve.ctrlpoints = [To.point(point) for point in points]
         JordanCurve.from_full_curve(curve)
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -55,7 +55,7 @@ class TestQuadraticJordan:
         with pytest.raises(TypeError):
             JordanCurve("asd")
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -83,7 +83,7 @@ class TestQuadraticJordan:
         test = np.array(test, dtype="float64")
         assert np.all(test == good)
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -113,7 +113,7 @@ class TestQuadraticJordan:
         test = np.array(test, dtype="float64")
         np.testing.assert_allclose(test, good)
 
-    @pytest.mark.order(6)
+    @pytest.mark.order(14)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -128,7 +128,7 @@ class TestQuadraticJordan:
         pass
 
 
-@pytest.mark.order(6)
+@pytest.mark.order(14)
 @pytest.mark.dependency(
     depends=[
         "TestQuadraticJordan::test_end",

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -10,7 +10,7 @@ import pytest
 from shapepy.geometry.jordancurve import IntegrateJordan, JordanCurve
 
 
-@pytest.mark.order(4)
+@pytest.mark.order(12)
 @pytest.mark.dependency(
     depends=[
         "tests/geometry/test_polygon.py::test_end",
@@ -23,12 +23,12 @@ def test_begin():
 
 
 class TestJordanPolygon:
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestJordanPolygon::test_begin"])
     def test_creation(self):
@@ -38,7 +38,7 @@ class TestJordanPolygon:
         points = [(0, 0), (1, 0), (1, 1), (0, 1)]
         JordanCurve.from_vertices(points)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -50,7 +50,7 @@ class TestJordanPolygon:
         with pytest.raises(TypeError):
             JordanCurve.from_vertices("asd")
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -70,7 +70,7 @@ class TestJordanPolygon:
             assert last_point == first_point
             assert id(last_point) == id(first_point)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -97,7 +97,7 @@ class TestJordanPolygon:
             for neg1 in negatives:
                 assert neg0 == neg1
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -126,7 +126,7 @@ class TestJordanPolygon:
         assert square != postri1
         assert square != postri2
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -151,7 +151,7 @@ class TestJordanPolygon:
                 # assert ~(~pos) == pos
                 # assert ~(~neg) == neg
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -202,7 +202,7 @@ class TestJordanPolygon:
         test = np.array(square1 & square0, dtype="float64")
         assert np.all(test == good)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -221,12 +221,12 @@ class TestJordanPolygon:
 
 
 class TestTransformationPolygon:
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["TestJordanPolygon::test_end"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestTransformationPolygon::test_begin"])
     def test_move(self):
@@ -240,7 +240,7 @@ class TestTransformationPolygon:
 
         assert test_square == good_square
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -256,7 +256,7 @@ class TestTransformationPolygon:
         test_rectangle.scale(2, 3)
         assert test_rectangle == good_rectangle
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -277,7 +277,7 @@ class TestTransformationPolygon:
         test_square.rotate(60, degrees=True)
         assert test_square == good_square
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -305,7 +305,7 @@ class TestTransformationPolygon:
         assert test_square == orig_square
         assert test_square != inve_square
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -323,7 +323,7 @@ class TestTransformationPolygon:
         test_square.split((0, 2, 3), (0.5, 0.5, 0.5))
         assert test_square == good_square
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(20)
     @pytest.mark.dependency(
         depends=[
@@ -355,7 +355,7 @@ class TestTransformationPolygon:
         assert len(test_ids) == len(good_ids)
         assert test_ids == good_ids
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -372,7 +372,7 @@ class TestTransformationPolygon:
 
 
 class TestIntegrateJordan:
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(
         depends=[
             "test_begin",
@@ -383,7 +383,7 @@ class TestIntegrateJordan:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrateJordan::test_begin"])
     def test_winding_regular_polygon(self):
@@ -401,7 +401,7 @@ class TestIntegrateJordan:
             wind = IntegrateJordan.winding_number(jordancurve)
             assert abs(wind + 1) < 1e-9
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrateJordan::test_begin"])
     def test_lenght_triangle(self):
@@ -417,7 +417,7 @@ class TestIntegrateJordan:
         good = -12
         assert abs(test - good) < 1e-3
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -450,7 +450,7 @@ class TestIntegrateJordan:
         assert lenght < 0
         assert abs(lenght + 4 * side) < 1e-9
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -467,7 +467,7 @@ class TestIntegrateJordan:
             jordan_curve = JordanCurve.from_vertices(ctrlpoints)
             assert (float(jordan_curve) - lenght) < 1e-9
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -483,7 +483,7 @@ class TestIntegrateJordan:
 
 
 class TestOthers:
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(
         depends=[
             "TestJordanPolygon::test_end",
@@ -493,7 +493,7 @@ class TestOthers:
     def test_begin(self):
         pass
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_print(self):
         points = [(1, 1), (2, 2), (0, 3)]
@@ -508,7 +508,7 @@ class TestOthers:
 
         str(triangle.vertices)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_self_intersection(self):
         points = [(0, 0), (1, 0), (0, 1)]
@@ -534,7 +534,7 @@ class TestOthers:
         )
         assert bool(inters)
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_clean(self):
         verticesa = [(-1, 0), (0, 0), (1, 0), (0, 1)]
@@ -565,7 +565,7 @@ class TestOthers:
         jordanb = JordanCurve.from_vertices(verticesb)
         assert jordana == jordanb
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(
         depends=["TestOthers::test_begin", "TestOthers::test_clean"]
     )
@@ -576,7 +576,7 @@ class TestOthers:
         jordanb = JordanCurve.from_vertices(verticesb)
         assert jordana == jordanb
 
-    @pytest.mark.order(4)
+    @pytest.mark.order(12)
     @pytest.mark.dependency(
         depends=[
             "TestOthers::test_begin",
@@ -590,7 +590,7 @@ class TestOthers:
         pass
 
 
-@pytest.mark.order(4)
+@pytest.mark.order(12)
 @pytest.mark.dependency(
     depends=[
         "TestJordanPolygon::test_end",

--- a/tests/geometry/test_polygon.py
+++ b/tests/geometry/test_polygon.py
@@ -9,7 +9,7 @@ import pytest
 from shapepy.geometry.point import Point2D
 
 
-@pytest.mark.order(2)
+@pytest.mark.order(11)
 @pytest.mark.dependency(
     depends=[
         "tests/scalar/test_reals.py::test_all",
@@ -21,12 +21,12 @@ def test_begin():
 
 
 class TestPoint:
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestPoint::test_begin"])
     def test_creation(self):
@@ -44,7 +44,7 @@ class TestPoint:
         with pytest.raises(TypeError):
             Point2D([0, 0])
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=["TestPoint::test_begin", "TestPoint::test_creation"]
@@ -57,7 +57,7 @@ class TestPoint:
         with pytest.raises(TypeError):
             Point2D(1, None)
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -75,7 +75,7 @@ class TestPoint:
         assert point[0] == 1
         assert point[1] == 2
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -106,7 +106,7 @@ class TestPoint:
 
         assert pointa != (12, 5)
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -139,7 +139,7 @@ class TestPoint:
         point = Point2D(5.0, 12.0)
         assert abs(point) == 13
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -164,7 +164,7 @@ class TestPoint:
         assert pointa @ pointb == 2
         assert pointb @ pointa == 2
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=["TestPoint::test_begin", "TestPoint::test_creation"]
@@ -185,7 +185,7 @@ class TestPoint:
         assert pointa ^ pointb == 0
         assert pointb ^ pointa == 0
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -205,7 +205,7 @@ class TestPoint:
         assert pta ^ ptb == pta[0] * ptb[1] - pta[1] * ptb[0]
         assert ptb ^ pta == pta[0] * ptb[1] - pta[1] * ptb[0]
 
-    @pytest.mark.order(2)
+    @pytest.mark.order(11)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -224,7 +224,7 @@ class TestPoint:
         pass
 
 
-@pytest.mark.order(2)
+@pytest.mark.order(11)
 @pytest.mark.dependency(
     depends=[
         "TestPoint::test_end",
@@ -241,7 +241,7 @@ def test_print():
     print(type(pointb))
 
 
-@pytest.mark.order(2)
+@pytest.mark.order(11)
 @pytest.mark.dependency(
     depends=[
         "TestPoint::test_end",

--- a/tests/plot/test_plot.py
+++ b/tests/plot/test_plot.py
@@ -10,7 +10,7 @@ from shapepy import ShapePloter
 from shapepy.bool2d.primitive import Primitive
 
 
-@pytest.mark.order(13)
+@pytest.mark.order(51)
 @pytest.mark.dependency(
     depends=[
         "tests/bool2d/test_shape.py::test_end",
@@ -22,12 +22,12 @@ def test_begin():
 
 
 class TestPlot:
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.dependency(depends=["test_begin"])
     def test_begin(self):
         pass
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestPlot::test_begin"])
     def test_create(self):
@@ -38,7 +38,7 @@ class TestPlot:
         ShapePloter(ax=ax)
         ShapePloter(fig=fig, ax=ax)
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -61,7 +61,7 @@ class TestPlot:
 
         # plt.show()
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -85,7 +85,7 @@ class TestPlot:
         plt = ShapePloter()
         plt.plot(shape)
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -103,7 +103,7 @@ class TestPlot:
         plt = ShapePloter()
         plt.plot(shape, fill_color="cyan")
 
-    @pytest.mark.order(13)
+    @pytest.mark.order(51)
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(
         depends=[
@@ -118,7 +118,7 @@ class TestPlot:
         pass
 
 
-@pytest.mark.order(13)
+@pytest.mark.order(51)
 @pytest.mark.dependency(
     depends=[
         "test_begin",


### PR DESCRIPTION
Reorder tests dependencies to allow further insertion of more tests:
* `scalar` : from `1` to `10`
* `geometry` : from `11` to `20`
* `bool2d`: from `21` to `50`
* `plot`: from `51` to `60`