### PR TITLE
Ignore the coverage of ValueError, TypeError and NotExpectedError

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,3 +8,6 @@ exclude_lines =
 
     # Don't complain if tests don't hit defensive assertion code:
     raise NotImplementedError
+    raise NotExpectedError
+    raise ValueError
+    raise TypeError

--- a/src/shapepy/tools.py
+++ b/src/shapepy/tools.py
@@ -96,3 +96,7 @@ def vectorize(position: int = 0, dimension: int = 0):
         return wrapper
 
     return decorator
+
+
+class NotExpectedError(Exception):
+    """Raised when arrives in a section that were not expected"""


### PR DESCRIPTION
Most of the raisers are only verification of the inputs.

Relates to #31 