### PR TITLE
Move integration over a segment into a different file

### DIFF
--- a/src/shapepy/__init__.py
+++ b/src/shapepy/__init__.py
@@ -18,7 +18,7 @@ from shapepy.bool2d.shape import (
 )
 from shapepy.geometry.jordancurve import IntegrateJordan, JordanCurve
 from shapepy.geometry.point import Point2D
-from shapepy.geometry.segment import IntegratePlanar, Segment
+from shapepy.geometry.segment import Segment
 from shapepy.plot.plot import ShapePloter
 
 __version__ = importlib.metadata.version("shapepy")

--- a/src/shapepy/geometry/integral.py
+++ b/src/shapepy/geometry/integral.py
@@ -1,0 +1,140 @@
+"""
+Contains functions to integrate over a segment
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+import numpy as np
+import pynurbs
+
+from ..scalar.quadrature import (
+    closed_linspace,
+    inner,
+    open_linspace,
+    open_newton_cotes,
+)
+from ..scalar.reals import Math
+from ..tools import Is
+from .point import Point2D
+from .segment import Segment
+
+
+def vertical(
+    curve: Segment,
+    expx: int = 0,
+    expy: int = 0,
+    nnodes: Union[None, int] = None,
+):
+    """Computes the integral I
+
+    I = int_C x^expx * y^expy * dy
+
+    """
+    if not Is.instance(curve, Segment):
+        raise TypeError
+    if not Is.integer(expx) or expx < 0:
+        raise ValueError
+    if not Is.integer(expy) or expy < 0:
+        raise ValueError
+    if nnodes is None:
+        nnodes = 3 + expx + expy + curve.degree
+    elif not Is.integer(nnodes) or nnodes < 0:
+        raise ValueError
+    dcurve = curve.derivate()
+    nodes = open_linspace(nnodes)
+    poids = pynurbs.heavy.IntegratorArray.open_newton_cotes(nnodes)
+    points = curve(nodes)
+    xvals = tuple(point[0] ** expx for point in points)
+    yvals = tuple(point[1] ** expy for point in points)
+    dyvals = tuple(point[1] for point in dcurve(nodes))
+    funcvals = tuple(map(np.prod, zip(xvals, yvals, dyvals)))
+    return np.inner(poids, funcvals)
+
+
+def polynomial(
+    curve: Segment, expx: int, expy: int, nnodes: Union[None, int] = None
+):
+    """
+    Computes the integral
+
+    I = int_C x^expx * y^expy * ds
+    """
+    if not Is.instance(curve, Segment):
+        raise TypeError
+    if nnodes is None:
+        nnodes = 3 + expx + expy + curve.degree
+    elif not Is.integer(nnodes) or nnodes < 0:
+        raise ValueError
+    assert expx == 0
+    assert expy == 0
+    dcurve = curve.derivate()
+    nodes = open_linspace(nnodes)
+    weights = open_newton_cotes(nnodes)
+    funcvals = tuple(abs(point) for point in dcurve(nodes))
+    return float(inner(weights, funcvals))
+
+
+def lenght(curve: Segment, nnodes: int = 5):
+    """Computes the integral I
+
+        I = int_{C} ds
+
+    Given the control points P of a bezier curve C(u) of
+    degree p
+
+        C(u) = sum_{i=0}^{p} B_{i,p}(u) * P_i
+
+        I = int_{0}^{1} abs(C'(u)) * du
+
+    """
+    return polynomial(curve, 0, 0, nnodes)
+
+
+def area(curve: Segment, nnodes: Union[None, int] = None):
+    """Computes the integral I
+
+    I = int_0^1 x * dy
+
+    """
+    return vertical(curve, 1, 0, nnodes)
+
+
+def winding_number_linear(
+    pointa: Point2D, pointb: Point2D, center: Point2D
+) -> float:
+    """
+    Computes the winding number defined by the given points.
+    It means, it's the angle made between the vector
+    (pointb - center) and (pointa - center)
+    """
+    anglea = np.arctan2(
+        float(pointa[1] - center[1]), float(pointa[0] - center[0])
+    )
+    angleb = np.arctan2(
+        float(pointb[1] - center[1]), float(pointb[0] - center[0])
+    )
+    wind = (angleb - anglea) / Math.tau
+    if abs(wind) < 0.5:
+        return wind
+    return wind - 1 if wind > 0 else wind + 1
+
+
+def winding_number(
+    curve: Segment,
+    center: Point2D = (0.0, 0.0),
+    nnodes: Union[None, int] = None,
+) -> float:
+    """
+    Computes the integral for a bezier curve of given control points
+    """
+    assert Is.instance(curve, Segment)
+    nnodes = curve.npts if nnodes is None else nnodes
+    nodes = closed_linspace(nnodes)
+    total = 0
+    for nodea, nodeb in zip(nodes[:-1], nodes[1:]):
+        pointa = curve(nodea)
+        pointb = curve(nodeb)
+        total += winding_number_linear(pointa, pointb, center)
+    return total

--- a/src/shapepy/geometry/jordancurve.py
+++ b/src/shapepy/geometry/jordancurve.py
@@ -13,9 +13,10 @@ import numpy as np
 
 from shapepy.geometry.box import Box
 from shapepy.geometry.point import Point2D
-from shapepy.geometry.segment import IntegratePlanar, Segment
+from shapepy.geometry.segment import Segment
 
 from ..tools import Is, To
+from . import integral
 
 
 class IntegrateJordan:
@@ -39,7 +40,7 @@ class IntegrateJordan:
         assert nnodes is None or Is.integer(nnodes)
         total = 0
         for bezier in jordan.segments:
-            total += IntegratePlanar.vertical(bezier, expx, expy, nnodes)
+            total += integral.vertical(bezier, expx, expy, nnodes)
         return total
 
     @staticmethod
@@ -55,7 +56,7 @@ class IntegrateJordan:
         assert nnodes is None or Is.integer(nnodes)
         total = 0
         for bezier in jordan.segments:
-            total += IntegratePlanar.polynomial(bezier, expx, expy, nnodes)
+            total += integral.polynomial(bezier, expx, expy, nnodes)
         return total
 
     @staticmethod
@@ -65,10 +66,10 @@ class IntegrateJordan:
         """
         assert Is.instance(jordan, JordanCurve)
         assert nnodes is None or Is.integer(nnodes)
-        lenght = 0
+        length = 0
         for bezier in jordan.segments:
-            lenght += IntegratePlanar.lenght(bezier, nnodes)
-        return lenght
+            length += integral.lenght(bezier, nnodes)
+        return length
 
     @staticmethod
     def area(jordan: JordanCurve, nnodes: Optional[int] = None) -> float:
@@ -79,7 +80,7 @@ class IntegrateJordan:
         assert nnodes is None or Is.integer(nnodes)
         area = 0
         for bezier in jordan.segments:
-            area += IntegratePlanar.area(bezier, nnodes)
+            area += integral.area(bezier, nnodes)
         return area
 
     @staticmethod
@@ -98,7 +99,7 @@ class IntegrateJordan:
                 if center in bezier:
                     return 0.5 if float(jordan) > 0 else -0.5
         for bezier in jordan.segments:
-            wind += IntegratePlanar.winding_number(bezier, center, nnodes)
+            wind += integral.winding_number(bezier, center, nnodes)
         return round(wind)
 
 

--- a/src/shapepy/scalar/bezier.py
+++ b/src/shapepy/scalar/bezier.py
@@ -11,6 +11,7 @@ from ..tools import Is, To
 from .polynomial import Polynomial
 from .polynomial import derivate as polyderiv
 from .polynomial import scale, shift
+from .quadrature import inner
 from .reals import Math, Rational, Real
 
 
@@ -49,16 +50,6 @@ def inverse_caract_matrix(degree: int) -> Tuple[Tuple[Rational, ...], ...]:
             val = To.rational(Math.binom(degree - j, i), Math.binom(degree, i))
             matrix[degree - j][i] = val
     return tuple(map(tuple, matrix))
-
-
-def inner(vectora: Iterable[Real], vectorb: Iterable[Real]) -> Real:
-    """Returns the inner product of two vectors"""
-    if not Is.iterable(vectora) or not Is.iterable(vectorb):
-        raise TypeError("Expected two iterables")
-    vectora = tuple(vectora)
-    vectorb = tuple(vectorb)
-    result = vectora[0] * vectorb[0]
-    return sum((a * b for a, b in zip(vectora[1:], vectorb[1:])), start=result)
 
 
 def bezier2polynomial(bezier: Bezier) -> Polynomial:

--- a/src/shapepy/scalar/quadrature.py
+++ b/src/shapepy/scalar/quadrature.py
@@ -1,0 +1,84 @@
+"""
+Defines the functions used to numerical integration
+"""
+
+from functools import lru_cache
+from typing import Iterable, Tuple
+
+import pynurbs
+
+from ..tools import Is, To
+from .reals import Rational, Real
+
+
+def inner(vectora: Iterable[Real], vectorb: Iterable[Real]) -> Real:
+    """Returns the inner product of two vectors"""
+    if not Is.iterable(vectora) or not Is.iterable(vectorb):
+        raise TypeError("Expected two iterables")
+    vectora = tuple(vectora)
+    vectorb = tuple(vectorb)
+    result = vectora[0] * vectorb[0]
+    return sum((a * b for a, b in zip(vectora[1:], vectorb[1:])), start=result)
+
+
+@lru_cache(maxsize=None)
+def closed_linspace(npts: int) -> Tuple[Rational, ...]:
+    """
+    Gives a set of numbers in interval [0, 1]
+
+    Example
+    -------
+    >>> closed_linspace(2)
+    (0, 1)
+    >>> closed_linspace(3)
+    (0, 0.5, 1)
+    >>> closed_linspace(4)
+    (0, 0.33, 0.66, 1)
+    >>> closed_linspace(5)
+    (0, 0.25, 0.5, 0.75, 1)
+    """
+    if not Is.integer(npts) or npts < 2:
+        raise ValueError("npts must be integer >= 2")
+    return tuple(To.rational(num, npts - 1) for num in range(npts))
+
+
+@lru_cache(maxsize=None)
+def open_linspace(npts: int) -> Tuple[Rational, ...]:
+    """
+    Gives a set of numbers in interval (0, 1)
+
+    Example
+    -------
+    >>> open_linspace(1)
+    (0.5, )
+    >>> open_linspace(2)
+    (0.33, 0.66)
+    >>> open_linspace(3)
+    (0.25, 0.50, 0.75)
+    """
+    if not Is.integer(npts) or npts < 1:
+        raise ValueError("npts must be integer >= 1")
+    return tuple(To.rational(num, 2 * npts) for num in range(1, 2 * npts, 2))
+
+
+@lru_cache(maxsize=None)
+def open_newton_cotes(npts: int) -> Tuple[Real, ...]:
+    """Returns the weight array for open newton-cotes formula
+    in the interval (0, 1)
+
+    Example
+    ------------
+    >>> open_newton_cotes(1)
+    (1, )
+    >>> open_newton_cotes(2)
+    (1/2, 1/2)
+    >>> open_newton_cotes(3)
+    (3/8, 1/4, 3/8)
+    >>> open_newton_cotes(4)
+    (13/48, 11/48, 11/48, 13/48)
+    >>> open_newton_cotes(5)
+    (275/1152, 25/288, 67/192, 25/288, 275/1152)
+
+    """
+    func = pynurbs.heavy.IntegratorArray.open_newton_cotes
+    return tuple(map(To.finite, func(npts)))

--- a/tests/geometry/test_integral.py
+++ b/tests/geometry/test_integral.py
@@ -1,0 +1,126 @@
+import math
+
+import numpy as np
+import pytest
+
+from shapepy.geometry import integral
+from shapepy.geometry.segment import Segment
+
+
+@pytest.mark.order(14)
+@pytest.mark.dependency(
+    depends=[
+        "tests/geometry/test_point.py::test_all",
+        "tests/geometry/test_box.py::test_all",
+        "tests/geometry/test_segment.py::test_all",
+    ],
+    scope="session",
+)
+def test_begin():
+    pass
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_lenght():
+    points = [(0, 0), (1, 0)]
+    curve = Segment(points)
+    assert integral.lenght(curve) == 1
+
+    points = [(1, 0), (0, 0)]
+    curve = Segment(points)
+    assert integral.lenght(curve) == 1
+
+    points = [(0, 1), (1, 0)]
+    curve = Segment(points)
+    assert abs(integral.lenght(curve) - np.sqrt(2)) < 1e-9
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_winding_triangles():
+    curve = Segment([(1, 0), (2, 0)])
+    wind = integral.winding_number(curve)
+    assert wind == 0
+
+    curve = Segment([(1, 0), (1, 1)])
+    wind = integral.winding_number(curve)
+    assert abs(wind - 0.125) < 1e-9
+
+    curve = Segment([(1, 0), (0, 1)])
+    wind = integral.winding_number(curve)
+    assert abs(wind - 0.25) < 1e-9
+
+    curve = Segment([(1, 0), (-0.5, np.sqrt(3) / 2)])
+    wind = integral.winding_number(curve)
+    assert abs(3 * wind - 1) < 1e-9
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(
+    depends=[
+        "test_begin",
+        "test_winding_triangles",
+    ]
+)
+def test_winding_unit_circle():
+    ntests = 1000
+    maxim = 0
+    for _ in range(ntests):
+        angle0 = np.random.uniform(0, 2 * np.pi)
+        good_wind = np.random.uniform(-0.5, 0.5)
+        angle1 = angle0 + 2 * np.pi * good_wind
+        point0 = (np.cos(angle0), np.sin(angle0))
+        point1 = (np.cos(angle1), np.sin(angle1))
+        curve = Segment([point0, point1])
+        test_wind = integral.winding_number(curve)
+        diff = abs(good_wind - test_wind)
+        maxim = max(maxim, diff)
+        assert abs(good_wind - test_wind) < 1e-9
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(
+    depends=[
+        "test_begin",
+        "test_winding_triangles",
+        "test_winding_unit_circle",
+    ]
+)
+def test_winding_regular_polygon():
+    for nsides in range(3, 10):
+        angles = np.linspace(0, math.tau, nsides + 1)
+        ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
+        pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
+        curves = tuple(Segment(pair) for pair in pairs)
+        for curve in curves:
+            wind = integral.winding_number(curve)
+            assert abs(nsides * wind - 1) < 1e-2
+
+    for nsides in range(3, 10):
+        angles = np.linspace(math.tau, 0, nsides + 1)
+        ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
+        pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
+        curves = tuple(Segment(pair) for pair in pairs)
+        for curve in curves:
+            wind = integral.winding_number(curve)
+            assert abs(nsides * wind + 1) < 1e-2
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(
+    depends=[
+        "test_begin",
+        "test_lenght",
+        "test_winding_triangles",
+        "test_winding_unit_circle",
+        "test_winding_regular_polygon",
+    ]
+)
+def test_all():
+    pass

--- a/tests/geometry/test_segment.py
+++ b/tests/geometry/test_segment.py
@@ -2,13 +2,11 @@
 This file contains tests functions to test the module polygon.py
 """
 
-import math
 from fractions import Fraction
 
-import numpy as np
 import pytest
 
-from shapepy.geometry.segment import IntegratePlanar, Math, Segment
+from shapepy.geometry.segment import Segment
 
 
 @pytest.mark.order(13)
@@ -56,114 +54,6 @@ class TestDerivate:
         depends=[
             "TestDerivate::test_begin",
             "TestDerivate::test_planar_bezier",
-        ]
-    )
-    def test_end(self):
-        pass
-
-
-class TestIntegrate:
-    @pytest.mark.order(13)
-    @pytest.mark.dependency(depends=["test_begin"])
-    def test_begin(self):
-        pass
-
-    @pytest.mark.order(13)
-    @pytest.mark.timeout(10)
-    @pytest.mark.dependency(depends=["TestIntegrate::test_begin"])
-    def test_lenght(self):
-        points = [(0, 0), (1, 0)]
-        curve = Segment(points)
-        assert IntegratePlanar.lenght(curve) == 1
-
-        points = [(1, 0), (0, 0)]
-        curve = Segment(points)
-        assert IntegratePlanar.lenght(curve) == 1
-
-        points = [(0, 1), (1, 0)]
-        curve = Segment(points)
-        assert abs(IntegratePlanar.lenght(curve) - np.sqrt(2)) < 1e-9
-
-    @pytest.mark.order(13)
-    @pytest.mark.timeout(10)
-    @pytest.mark.dependency(depends=["TestIntegrate::test_begin"])
-    def test_winding_triangles(self):
-        curve = Segment([(1, 0), (2, 0)])
-        wind = IntegratePlanar.winding_number(curve)
-        assert wind == 0
-
-        curve = Segment([(1, 0), (1, 1)])
-        wind = IntegratePlanar.winding_number(curve)
-        assert abs(wind - 0.125) < 1e-9
-
-        curve = Segment([(1, 0), (0, 1)])
-        wind = IntegratePlanar.winding_number(curve)
-        assert abs(wind - 0.25) < 1e-9
-
-        curve = Segment([(1, 0), (-0.5, np.sqrt(3) / 2)])
-        wind = IntegratePlanar.winding_number(curve)
-        assert abs(3 * wind - 1) < 1e-9
-
-    @pytest.mark.order(13)
-    @pytest.mark.timeout(10)
-    @pytest.mark.dependency(
-        depends=[
-            "TestIntegrate::test_begin",
-            "TestIntegrate::test_winding_triangles",
-        ]
-    )
-    def test_winding_unit_circle(self):
-        ntests = 1000
-        maxim = 0
-        for k in range(ntests):
-            angle0 = np.random.uniform(0, 2 * np.pi)
-            good_wind = np.random.uniform(-0.5, 0.5)
-            angle1 = angle0 + 2 * np.pi * good_wind
-            point0 = (np.cos(angle0), np.sin(angle0))
-            point1 = (np.cos(angle1), np.sin(angle1))
-            curve = Segment([point0, point1])
-            test_wind = IntegratePlanar.winding_number(curve)
-            diff = abs(good_wind - test_wind)
-            maxim = max(maxim, diff)
-            assert abs(good_wind - test_wind) < 1e-9
-
-    @pytest.mark.order(13)
-    @pytest.mark.timeout(10)
-    @pytest.mark.dependency(
-        depends=[
-            "TestIntegrate::test_begin",
-            "TestIntegrate::test_winding_triangles",
-            "TestIntegrate::test_winding_unit_circle",
-        ]
-    )
-    def test_winding_regular_polygon(self):
-        for nsides in range(3, 10):
-            angles = np.linspace(0, math.tau, nsides + 1)
-            ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-            pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
-            curves = tuple(Segment(pair) for pair in pairs)
-            for curve in curves:
-                wind = IntegratePlanar.winding_number(curve)
-                assert abs(nsides * wind - 1) < 1e-2
-
-        for nsides in range(3, 10):
-            angles = np.linspace(math.tau, 0, nsides + 1)
-            ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-            pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
-            curves = tuple(Segment(pair) for pair in pairs)
-            for curve in curves:
-                wind = IntegratePlanar.winding_number(curve)
-                assert abs(nsides * wind + 1) < 1e-2
-
-    @pytest.mark.order(13)
-    @pytest.mark.timeout(10)
-    @pytest.mark.dependency(
-        depends=[
-            "TestIntegrate::test_begin",
-            "TestIntegrate::test_lenght",
-            "TestIntegrate::test_winding_triangles",
-            "TestIntegrate::test_winding_unit_circle",
-            "TestIntegrate::test_winding_regular_polygon",
         ]
     )
     def test_end(self):
@@ -334,7 +224,6 @@ def test_print():
         "test_begin",
         "test_build",
         "TestDerivate::test_end",
-        "TestIntegrate::test_end",
         "TestOperations::test_end",
         "TestContains::test_end",
         "TestSplitUnite::test_end",


### PR DESCRIPTION
The `geometry/segment.py` contained `IntegratePlanar` class that had static methods to integrate over a segment.

These methods were moved to the file `geometry/integral.py`.

The file `scalar/quadrature.py` was created to store the functions for numerical integration