### PR TITLE
Fix sphinx docs error due to bad format and position of staticmethod decorator

### DIFF
--- a/src/shapepy/scalar/bezier.py
+++ b/src/shapepy/scalar/bezier.py
@@ -4,7 +4,7 @@ Defines the Bezier class, that has the same basis as the Polynomial
 
 from __future__ import annotations
 
-from functools import cache
+from functools import lru_cache
 from typing import Iterable, Tuple, Union
 
 from ..tools import Is, To
@@ -13,7 +13,7 @@ from .quadrature import inner
 from .reals import Math, Rational, Real
 
 
-@cache
+@lru_cache(maxsize=None)
 def bezier_caract_matrix(degree: int) -> Tuple[Tuple[Rational, ...], ...]:
     """Returns the matrix [M] with the polynomial coefficients
 
@@ -35,7 +35,7 @@ def bezier_caract_matrix(degree: int) -> Tuple[Tuple[Rational, ...], ...]:
     return tuple(map(tuple, matrix))
 
 
-@cache
+@lru_cache(maxsize=None)
 def inverse_caract_matrix(degree: int) -> Tuple[Tuple[Rational, ...], ...]:
     """
     Returns the inverse matrix of the caract bezier matrix

--- a/src/shapepy/scalar/nodes_sample.py
+++ b/src/shapepy/scalar/nodes_sample.py
@@ -2,7 +2,7 @@
 Defines the NodeSampleFactory
 """
 
-from functools import cache
+from functools import lru_cache
 from typing import Tuple
 
 from ..tools import Is, To
@@ -16,7 +16,7 @@ class NodeSampleFactory:
     """
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def closed_linspace(npts: int) -> Tuple[Rational, ...]:
         """
         Gives a set of numbers in interval [0, 1]
@@ -37,7 +37,7 @@ class NodeSampleFactory:
         return tuple(To.rational(num, npts - 1) for num in range(npts))
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def closed_newton_cotes(npts: int) -> Tuple[Real]:
         """
         Gives a set of numbers in interval [0, 1]
@@ -58,7 +58,7 @@ class NodeSampleFactory:
         return tuple(To.rational(num, npts - 1) for num in range(npts))
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def open_newton_cotes(npts: int) -> Tuple[Real]:
         """
         Gives a set of numbers in interval (0, 1)
@@ -79,7 +79,7 @@ class NodeSampleFactory:
         return tuple(To.rational(num, npts + 1) for num in range(1, npts + 1))
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def custom_open_formula(npts: int) -> Tuple[Real]:
         """
         Gives a set of numbers in interval (0, 1)
@@ -102,7 +102,7 @@ class NodeSampleFactory:
         )
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def chebyshev(npts: int) -> Tuple[Real]:
         """
         Gives a set of numbers in interval (0, 1)

--- a/src/shapepy/scalar/quadrature.py
+++ b/src/shapepy/scalar/quadrature.py
@@ -2,7 +2,7 @@
 Defines the functions used to numerical integration
 """
 
-from functools import cache
+from functools import lru_cache
 from typing import Callable, Iterable, Tuple
 
 import numpy as np
@@ -262,7 +262,7 @@ class IntegratorFactory:
         return DirectIntegrator(map(convert, nodes), map(convert, weights))
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def custom_open_formula(
         npts: int, convert: type = To.rational
     ) -> DirectIntegrator:
@@ -297,7 +297,7 @@ class IntegratorFactory:
         return DirectIntegrator(map(convert, nodes), map(convert, weights))
 
     @staticmethod
-    @cache
+    @lru_cache(maxsize=None)
     def clenshaw_curtis(
         npts: int, convert: type = To.finite
     ) -> DirectIntegrator:
@@ -393,11 +393,11 @@ class AdaptativeIntegrator:
     ) -> Real:
         """Computes the integral of func in [a, b]"""
 
-        @cache
+        @lru_cache(maxsize=None)
         def cfunction(node: Real) -> Real:
             return function(node)
 
-        @cache
+        @lru_cache(maxsize=None)
         def cdirect(left: Real, right: Real) -> Real:
             return self.integrator.integrate(cfunction, (left, right))
 

--- a/src/shapepy/tools.py
+++ b/src/shapepy/tools.py
@@ -6,7 +6,7 @@ logging, errors, debugging, etc.
 from __future__ import annotations
 
 import types
-from functools import cache, wraps
+from functools import lru_cache, wraps
 from typing import Any, Set
 
 import numpy as np
@@ -109,7 +109,7 @@ class NotExpectedError(Exception):
     """Raised when arrives in a section that were not expected"""
 
 
-@cache
+@lru_cache(maxsize=None)
 def pow_keys(exp: int) -> Set[int]:
     """
     Computes the basis to exponentials


### PR DESCRIPTION
Sphinx shown error for
* Tables did not contain enough columns. Solution: erase some spaces
* `lru_cache` was not recognized. Probably it was due to the position of the `staticmethod` decorator