### PR TITLE
Create factory for Jordan Curve

### DIFF
--- a/docs/source/rst/jordan_curve.rst
+++ b/docs/source/rst/jordan_curve.rst
@@ -55,10 +55,9 @@ Creating a jordan curve
 
 There are 4 ways to create a ``JordanCurve`` instance:
 
-* From vertices: ``JordanCurve.from_vertices``
-* From segments: ``JordanCurve.from_segments``
-* From bezier control points: ``JordanCurve.from_ctrlpoints``
-* From full curve: ``JordanCurve.from_full_curve``
+* From segments: ``JordanCurve`` directly
+* From vertices: ``FactoryJordan.polygon``
+* From spline curve: ``FactoryJordan.spline_curve``
 
 From vertices
 -----------------------
@@ -73,7 +72,7 @@ This method creates polygonal shapes only
    # Create a list of vertices
    vertices = [(1, 2), (4, 0), (-1, -1), (-3, 1)]
    # Creates a quadrilateral jordan
-   jordan = JordanCurve.from_vertices(vertices)
+   jordan = FactoryJordan.polygon(vertices)
 
 .. image:: ../img/jordan_curve/from_vertices.svg
    :width: 50 %
@@ -89,12 +88,12 @@ This method can create shape of any degree
 
 .. code-block:: python
    
-   from shapepy import PlanarBezier, JordanCurve
-   segment0 = PlanarBezier([(0, 0), (4, 0)])
-   segment1 = PlanarBezier([(4, 0), (4, 3), (0, 3)])
-   segment2 = PlanarBezier([(0, 3), (0, 0)])
+   from shapepy import Segment, JordanCurve
+   segment0 = Segment([(0, 0), (4, 0)])
+   segment1 = Segment([(4, 0), (4, 3), (0, 3)])
+   segment2 = Segment([(0, 3), (0, 0)])
    segments = [segment0, segment1, segment2]
-   jordan = JordanCurve.from_segments(segments)
+   jordan = JordanCurve(segments)
 
 .. image:: ../img/jordan_curve/from_segments.svg
    :width: 50 %
@@ -102,28 +101,8 @@ This method can create shape of any degree
    :align: center
 
 
-From control points
--------------------
 
-This is similar to creating ``from_segments``, but we pass directly the control points
-
-
-.. code-block:: python
-   
-   from shapepy import JordanCurve
-   all_ctrlpoints = [[(0, 0), (4, 0)],
-                     [(4, 0), (4, 3), (0, 3)],
-                     [(0, 3), (0, 0)]]
-   jordan = JordanCurve.from_ctrlpoints(all_ctrlpoints)
-
-.. image:: ../img/jordan_curve/from_segments.svg
-   :width: 50 %
-   :alt: Example of jordan curve created from ctrlpoints
-   :align: center
-
-
-
-From full curve
+From spline
 ---------------
 
 For this case, we will use the package ``pynurbs``
@@ -138,7 +117,7 @@ For this case, we will use the package ``pynurbs``
                  (0, 3), (0, 3/2), (0, 0)]
    ctrlpoints = [Point2D(point) for point in ctrlpoints]
    curve = pynurbs.Curve(knotvector, ctrlpoints)
-   jordan = JordanCurve.from_full_curve(curve)
+   jordan = FactoryJordan.spline_curve(curve)
 
 .. image:: ../img/jordan_curve/from_segments.svg
    :width: 50 %

--- a/docs/source/rst/shape.rst
+++ b/docs/source/rst/shape.rst
@@ -103,7 +103,7 @@ You can also create your custom ``SimpleShape`` by using a passing a ``JordanCur
    
    from shapepy import JordanCurve, SimpleShape
    vertices = [(0, 0), (4, 0), (0, 3)]
-   jordan = JordanCurve.from_vertices(vertices)
+   jordan = FactoryJordan.polygon(vertices)
    simple = SimpleShape(jordan)
 
 It's possible to operate between two simple shapes:

--- a/src/shapepy/bool2d/primitive.py
+++ b/src/shapepy/bool2d/primitive.py
@@ -12,12 +12,12 @@ from typing import Tuple
 
 import numpy as np
 
-from shapepy.bool2d.shape import EmptyShape, SimpleShape, WholeShape
-from shapepy.geometry.jordancurve import JordanCurve
-from shapepy.geometry.point import Point2D
-from shapepy.geometry.segment import Segment
-
+from ..geometry.factory import FactoryJordan
+from ..geometry.jordancurve import JordanCurve
+from ..geometry.point import Point2D
+from ..geometry.segment import Segment
 from ..tools import Is, To
+from .shape import EmptyShape, SimpleShape, WholeShape
 
 
 class Primitive:
@@ -106,7 +106,7 @@ class Primitive:
 
         """
         vertices = tuple(map(To.point, vertices))
-        jordan_curve = JordanCurve.from_vertices(vertices)
+        jordan_curve = FactoryJordan.polygon(vertices)
         return SimpleShape(jordan_curve)
 
     @staticmethod
@@ -235,7 +235,7 @@ class Primitive:
         new_bezier = Segment([start_point, middle_point, end_point])
         beziers.append(new_bezier)
 
-        jordan_curve = JordanCurve.from_segments(beziers)
+        jordan_curve = JordanCurve(beziers)
         jordan_curve.move(center)
         circle = SimpleShape(jordan_curve)
         return circle

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -171,7 +171,7 @@ class FollowPath:
             new_bezier = jordans[index_jordan].segments[index_segment]
             new_bezier = copy(new_bezier)
             beziers.append(new_bezier)
-        new_jordan = JordanCurve.from_segments(beziers)
+        new_jordan = JordanCurve(beziers)
         return new_jordan
 
     @staticmethod

--- a/src/shapepy/geometry/factory.py
+++ b/src/shapepy/geometry/factory.py
@@ -1,0 +1,77 @@
+"""
+Defines the Factory to create Jordan Curves
+"""
+
+from typing import Tuple
+
+from ..tools import To
+from .jordancurve import JordanCurve
+from .point import Point2D
+from .segment import Segment, clean_segment
+
+
+class FactoryJordan:
+    """
+    Define functions to create Jordan Curves
+    """
+
+    @staticmethod
+    def polygon(vertices: Tuple[Point2D, ...]) -> JordanCurve:
+        """Initialize a polygonal JordanCurve from a list of vertices,
+
+        :param vertices: The list vertices
+        :type vertices: Tuple[Point2D]
+        :return: The created jordan curve
+        :rtype: JordanCurve
+
+        Example use
+        -----------
+
+        >>> from shapepy import JordanCurve
+        >>> all_ctrlpoints = [(0, 0), (4, 0), (0, 3)]
+        >>> FactoryJordan.polygon(all_ctrlpoints)
+        Jordan Curve of degree 1 and vertices
+        ((0, 0), (4, 0), (0, 3))
+
+        """
+        vertices = list(map(To.point, vertices))
+        nverts = len(vertices)
+        vertices.append(vertices[0])
+        beziers = [0] * nverts
+        for i in range(nverts):
+            ctrlpoints = vertices[i : i + 2]
+            new_bezier = Segment(ctrlpoints)
+            beziers[i] = new_bezier
+        return JordanCurve(beziers)
+
+    @staticmethod
+    def spline_curve(spline_curve) -> JordanCurve:
+        """Initialize a JordanCurve from a spline curve,
+
+        :param spline_curve: The spline curve to split.
+                Ideally ``pynurbs.Curve`` instance
+        :type spline_curve: SplineCurve
+        :return: The created jordan curve
+        :rtype: JordanCurve
+
+        Example use
+        -----------
+
+        >>> import pynurbs
+        >>> from shapepy import Point2D, JordanCurve
+        >>> knotvector = (0, 0, 0, 0.5, 1, 1, 1)
+        >>> ctrlpoints = [(0, 0), (4, 0), (0, 3), (0, 0)]
+        >>> ctrlpoints = [Point2D(point
+        ) for point in ctrlpoints]
+        >>> curve = pynurbs.Curve(knotvector, ctrlpoints)
+        >>> jordan = FactoryJordan.spline_curve(curve)
+        >>> print(jordan)
+        Jordan Curve of degree 2 and vertices
+        ((0.0, 0.0), (4.0, 0.0), (2.0, 1.5), (0.0, 3.0))
+
+        """
+        beziers = spline_curve.split(spline_curve.knots)
+        segments = (
+            clean_segment(Segment(bezier.ctrlpoints)) for bezier in beziers
+        )
+        return JordanCurve(segments)

--- a/src/shapepy/geometry/piecewise.py
+++ b/src/shapepy/geometry/piecewise.py
@@ -188,9 +188,9 @@ class PiecewiseCurve:
         -----------
         >>> from shapepy import JordanCurve
         >>> vertices_a = [(0, 0), (2, 0), (2, 2), (0, 2)]
-        >>> jordan_a = JordanCurve.from_vertices(vertices_a)
+        >>> jordan_a = FactoryJordan.polygon(vertices_a)
         >>> vertices_b = [(1, 1), (3, 1), (3, 3), (1, 3)]
-        >>> jordan_b = JordanCurve.from_vertices(vertices_b)
+        >>> jordan_b = FactoryJordan.polygon(vertices_b)
         >>> jordan_a.intersection(jordan_b)
         ((1, 0, 1/2, 1/2), (2, 3, 1/2, 1/2))
 

--- a/tests/bool2d/test_bool_finite_intersect.py
+++ b/tests/bool2d/test_bool_finite_intersect.py
@@ -7,7 +7,7 @@ import pytest
 
 from shapepy.bool2d.primitive import Primitive
 from shapepy.bool2d.shape import SimpleShape
-from shapepy.geometry.jordancurve import JordanCurve
+from shapepy.geometry.factory import FactoryJordan
 
 
 @pytest.mark.order(32)
@@ -76,10 +76,10 @@ class TestIntersectionSimple:
         square1 = Primitive.regular_polygon(nsides=4, radius=2, center=(1, 0))
 
         left_points = [(0, 1), (-1, 2), (-3, 0), (-1, -2), (0, -1), (-1, 0)]
-        left_jordanpoly = JordanCurve.from_vertices(left_points)
+        left_jordanpoly = FactoryJordan.polygon(left_points)
         left_shape = SimpleShape(left_jordanpoly)
         right_points = [(0, 1), (1, 0), (0, -1), (1, -2), (3, 0), (1, 2)]
-        right_jordanpoly = JordanCurve.from_vertices(right_points)
+        right_jordanpoly = FactoryJordan.polygon(right_points)
         right_shape = SimpleShape(right_jordanpoly)
 
         assert square0 - square1 == left_shape

--- a/tests/bool2d/test_contains.py
+++ b/tests/bool2d/test_contains.py
@@ -15,7 +15,7 @@ from shapepy.bool2d.shape import (
     EmptyShape,
     WholeShape,
 )
-from shapepy.geometry.jordancurve import JordanCurve
+from shapepy.geometry.factory import FactoryJordan
 
 
 @pytest.mark.order(23)
@@ -104,12 +104,12 @@ class TestObjectsInEmptyWhole:
         whole = WholeShape()
 
         vertices = [(0, 0), (1, 0), (0, 1)]
-        jordan = JordanCurve.from_vertices(vertices)
+        jordan = FactoryJordan.polygon(vertices)
         assert jordan not in empty
         assert jordan in whole
 
         vertices = [(0, 0), (0, 1), (1, 0)]
-        jordan = JordanCurve.from_vertices(vertices)
+        jordan = FactoryJordan.polygon(vertices)
         assert jordan not in empty
         assert jordan in whole
 
@@ -202,7 +202,7 @@ class TestObjectsInJordan:
     def test_boundary_point(self):
         # Test if the points are in boundary
         vertices = [(0, 0), (1, 0), (0, 1)]
-        triangle = JordanCurve.from_vertices(vertices)
+        triangle = FactoryJordan.polygon(vertices)
         assert (0, 0) in triangle
         assert (1, 0) in triangle
         assert (0, 1) in triangle
@@ -211,7 +211,7 @@ class TestObjectsInJordan:
         assert (0, 0.5) in triangle
 
         vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        square = JordanCurve.from_vertices(vertices)
+        square = FactoryJordan.polygon(vertices)
         assert (0, 0) in square
         assert (1, 0) in square
         assert (1, 1) in square
@@ -231,11 +231,11 @@ class TestObjectsInJordan:
     def test_interior_point(self):
         # Test if the interior points are not in boundary
         vertices = [(0, 0), (3, 0), (0, 3)]
-        triangle = JordanCurve.from_vertices(vertices)
+        triangle = FactoryJordan.polygon(vertices)
         assert (1, 1) not in triangle
 
         vertices = [(0, 0), (2, 0), (2, 2), (0, 2)]
-        square = JordanCurve.from_vertices(vertices)
+        square = FactoryJordan.polygon(vertices)
         assert (1, 1) not in square
 
     @pytest.mark.order(23)
@@ -247,11 +247,11 @@ class TestObjectsInJordan:
     )
     def test_exterior_point(self):
         # Test if the exterior points are not in boundary
-        triangle = JordanCurve.from_vertices([(0, 0), (1, 0), (0, 1)])
+        triangle = FactoryJordan.polygon([(0, 0), (1, 0), (0, 1)])
         assert (-1, -1) not in triangle
         assert (1, 1) not in triangle
 
-        square = JordanCurve.from_vertices([(0, 0), (1, 0), (1, 1), (0, 1)])
+        square = FactoryJordan.polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
         assert (-1, -1) not in square
         assert (2, 2) not in square
 

--- a/tests/bool2d/test_shape.py
+++ b/tests/bool2d/test_shape.py
@@ -9,8 +9,8 @@ import pytest
 
 from shapepy.bool2d.primitive import Primitive
 from shapepy.bool2d.shape import SimpleShape
+from shapepy.geometry.factory import FactoryJordan
 from shapepy.geometry.integral import IntegrateJordan
-from shapepy.geometry.jordancurve import JordanCurve
 
 
 @pytest.mark.order(25)
@@ -141,7 +141,7 @@ class TestOthers:
     )
     def test_print(self):
         points = [(0, 0), (1, 0), (0, 1)]
-        jordancurve = JordanCurve.from_vertices(points)
+        jordancurve = FactoryJordan.polygon(points)
         shape = SimpleShape(jordancurve)
         str(shape)
         repr(shape)

--- a/tests/geometry/test_jordan_curve.py
+++ b/tests/geometry/test_jordan_curve.py
@@ -8,6 +8,7 @@ import numpy as np
 import pynurbs
 import pytest
 
+from shapepy.geometry.factory import FactoryJordan
 from shapepy.geometry.jordancurve import JordanCurve
 from shapepy.scalar.reals import To
 
@@ -42,7 +43,7 @@ class TestQuadraticJordan:
         points = [(0, -1), (2, 0), (0, 1), (0, 1), (0, -1)]
         curve = pynurbs.Curve(knotvector)
         curve.ctrlpoints = [To.point(point) for point in points]
-        JordanCurve.from_full_curve(curve)
+        FactoryJordan.spline_curve(curve)
 
     @pytest.mark.order(16)
     @pytest.mark.timeout(10)
@@ -72,12 +73,12 @@ class TestQuadraticJordan:
         pointsa = [(0, -2), (4, 0), (0, 2), (0, 0), (0, -2)]
         curvea = pynurbs.Curve(knotvector)
         curvea.ctrlpoints = [To.point(pt) for pt in pointsa]
-        jordana = JordanCurve.from_full_curve(curvea)
+        jordana = FactoryJordan.spline_curve(curvea)
 
         pointsb = [(3, -2), (-1, 0), (3, 2), (3, 0), (3, -2)]
         curveb = pynurbs.Curve(knotvector)
         curveb.ctrlpoints = [To.point(pt) for pt in pointsb]
-        jordanb = JordanCurve.from_full_curve(curveb)
+        jordanb = FactoryJordan.spline_curve(curveb)
 
         good = [(0, 0, 1 / 4, 1 / 4), (0, 0, 3 / 4, 3 / 4)]
         test = jordana & jordanb
@@ -101,13 +102,13 @@ class TestQuadraticJordan:
         # pointsa = np.array(pointsa, dtype="float64")
         curvea = pynurbs.Curve(knotvector)
         curvea.ctrlpoints = [To.point(pt) for pt in pointsa]
-        jordana = JordanCurve.from_full_curve(curvea)
+        jordana = FactoryJordan.spline_curve(curvea)
 
         pointsb = [(3, -2), (-1, 0), (3, 2), (3, 0), (3, -2)]
         # pointsb = np.array(pointsb, dtype="float64")
         curveb = pynurbs.Curve(knotvector)
         curveb.ctrlpoints = [To.point(pt) for pt in pointsb]
-        jordanb = JordanCurve.from_full_curve(curveb)
+        jordanb = FactoryJordan.spline_curve(curveb)
 
         good = [(0, 0, 0.25, 0.25), (0, 0, 0.75, 0.75)]
         test = jordana & jordanb

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -7,8 +7,9 @@ import math
 import numpy as np
 import pytest
 
+from shapepy.geometry.factory import FactoryJordan
 from shapepy.geometry.integral import IntegrateJordan
-from shapepy.geometry.jordancurve import JordanCurve, clean_jordan
+from shapepy.geometry.jordancurve import clean_jordan
 
 
 @pytest.mark.order(15)
@@ -36,10 +37,10 @@ class TestJordanPolygon:
     @pytest.mark.dependency(depends=["TestJordanPolygon::test_begin"])
     def test_creation(self):
         points = [(0, 0), (1, 0), (0, 1)]
-        JordanCurve.from_vertices(points)
+        FactoryJordan.polygon(points)
 
         points = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        JordanCurve.from_vertices(points)
+        FactoryJordan.polygon(points)
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)
@@ -51,7 +52,7 @@ class TestJordanPolygon:
     )
     def test_error_creation(self):
         with pytest.raises(ValueError):
-            JordanCurve.from_vertices("asd")
+            FactoryJordan.polygon("asd")
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(20)
@@ -64,7 +65,7 @@ class TestJordanPolygon:
     )
     def test_id_points(self):
         points = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        jordan = JordanCurve.from_vertices(points)
+        jordan = FactoryJordan.polygon(points)
         segments = jordan.segments
         for i, segi in enumerate(segments):
             segj = segments[(i + 1) % len(segments)]
@@ -84,17 +85,17 @@ class TestJordanPolygon:
         ]
     )
     def test_equal_curves(self):
-        postri0 = JordanCurve.from_vertices([(0, 0), (1, 0), (0, 1)])
-        postri1 = JordanCurve.from_vertices([(1, 0), (0, 1), (0, 0)])
-        postri2 = JordanCurve.from_vertices([(0, 1), (0, 0), (1, 0)])
+        postri0 = FactoryJordan.polygon([(0, 0), (1, 0), (0, 1)])
+        postri1 = FactoryJordan.polygon([(1, 0), (0, 1), (0, 0)])
+        postri2 = FactoryJordan.polygon([(0, 1), (0, 0), (1, 0)])
         positives = (postri0, postri1, postri2)
         for pos0 in positives:
             for pos1 in positives:
                 assert pos0 == pos1
 
-        negtri0 = JordanCurve.from_vertices([(0, 0), (0, 1), (1, 0)])
-        negtri1 = JordanCurve.from_vertices([(1, 0), (0, 0), (0, 1)])
-        negtri2 = JordanCurve.from_vertices([(0, 1), (1, 0), (0, 0)])
+        negtri0 = FactoryJordan.polygon([(0, 0), (0, 1), (1, 0)])
+        negtri1 = FactoryJordan.polygon([(1, 0), (0, 0), (0, 1)])
+        negtri2 = FactoryJordan.polygon([(0, 1), (1, 0), (0, 0)])
         negatives = (negtri0, negtri1, negtri2)
         for neg0 in negatives:
             for neg1 in negatives:
@@ -112,19 +113,19 @@ class TestJordanPolygon:
         ]
     )
     def test_nonequal_curves(self):
-        postri0 = JordanCurve.from_vertices([(0, 0), (1, 0), (0, 1)])
-        postri1 = JordanCurve.from_vertices([(1, 0), (0, 1), (0, 0)])
-        postri2 = JordanCurve.from_vertices([(0, 1), (0, 0), (1, 0)])
-        negtri0 = JordanCurve.from_vertices([(0, 0), (0, 1), (1, 0)])
-        negtri1 = JordanCurve.from_vertices([(1, 0), (0, 0), (0, 1)])
-        negtri2 = JordanCurve.from_vertices([(0, 1), (1, 0), (0, 0)])
+        postri0 = FactoryJordan.polygon([(0, 0), (1, 0), (0, 1)])
+        postri1 = FactoryJordan.polygon([(1, 0), (0, 1), (0, 0)])
+        postri2 = FactoryJordan.polygon([(0, 1), (0, 0), (1, 0)])
+        negtri0 = FactoryJordan.polygon([(0, 0), (0, 1), (1, 0)])
+        negtri1 = FactoryJordan.polygon([(1, 0), (0, 0), (0, 1)])
+        negtri2 = FactoryJordan.polygon([(0, 1), (1, 0), (0, 0)])
         positives = (postri0, postri1, postri2)
         negatives = (negtri0, negtri1, negtri2)
         for pos in positives:
             for neg in negatives:
                 assert pos != neg
 
-        square = JordanCurve.from_vertices([(0, 0), (1, 0), (1, 1), (0, 1)])
+        square = FactoryJordan.polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
         assert square != postri0
         assert square != postri1
         assert square != postri2
@@ -141,12 +142,12 @@ class TestJordanPolygon:
         ]
     )
     def test_invert_curves(self):
-        postri0 = JordanCurve.from_vertices([(0, 0), (1, 0), (0, 1)])
-        postri1 = JordanCurve.from_vertices([(1, 0), (0, 1), (0, 0)])
-        postri2 = JordanCurve.from_vertices([(0, 1), (0, 0), (1, 0)])
-        negtri0 = JordanCurve.from_vertices([(0, 0), (0, 1), (1, 0)])
-        negtri1 = JordanCurve.from_vertices([(1, 0), (0, 0), (0, 1)])
-        negtri2 = JordanCurve.from_vertices([(0, 1), (1, 0), (0, 0)])
+        postri0 = FactoryJordan.polygon([(0, 0), (1, 0), (0, 1)])
+        postri1 = FactoryJordan.polygon([(1, 0), (0, 1), (0, 0)])
+        postri2 = FactoryJordan.polygon([(0, 1), (0, 0), (1, 0)])
+        negtri0 = FactoryJordan.polygon([(0, 0), (0, 1), (1, 0)])
+        negtri1 = FactoryJordan.polygon([(1, 0), (0, 0), (0, 1)])
+        negtri2 = FactoryJordan.polygon([(0, 1), (1, 0), (0, 0)])
         for pos in (postri0, postri1, postri2):
             for neg in (negtri0, negtri1, negtri2):
                 assert pos == (~neg)
@@ -169,9 +170,9 @@ class TestJordanPolygon:
     )
     def test_intersection(self):
         vertices0 = [(1, 0), (-1, 2), (-3, 0), (-1, -2)]
-        square0 = JordanCurve.from_vertices(vertices0)
+        square0 = FactoryJordan.polygon(vertices0)
         vertices1 = [(-1, 0), (1, 2), (3, 0), (1, -2)]
-        square1 = JordanCurve.from_vertices(vertices1)
+        square1 = FactoryJordan.polygon(vertices1)
 
         equal_squares = tuple()
         assert square0 & square0 == equal_squares
@@ -183,7 +184,7 @@ class TestJordanPolygon:
         assert np.all(test == good)
 
         vertices1 = [(-1, 0), (1, -2), (3, 0), (1, 2)]
-        square1 = JordanCurve.from_vertices(vertices1)
+        square1 = FactoryJordan.polygon(vertices1)
 
         assert square0 & square0 == equal_squares
         assert square1 & square1 == equal_squares
@@ -194,7 +195,7 @@ class TestJordanPolygon:
         assert np.all(test == good)
 
         vertices1 = [(1, -2), (3, 0), (1, 2), (-1, 0)]
-        square1 = JordanCurve.from_vertices(vertices1)
+        square1 = FactoryJordan.polygon(vertices1)
 
         assert square0 & square0 == equal_squares
         assert square1 & square1 == equal_squares
@@ -234,10 +235,10 @@ class TestTransformationPolygon:
     @pytest.mark.dependency(depends=["TestTransformationPolygon::test_begin"])
     def test_move(self):
         good_square_pts = [(2, 4), (3, 4), (3, 5), (2, 5)]
-        good_square = JordanCurve.from_vertices(good_square_pts)
+        good_square = FactoryJordan.polygon(good_square_pts)
 
         test_square_pts = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        test_square = JordanCurve.from_vertices(test_square_pts)
+        test_square = FactoryJordan.polygon(test_square_pts)
         test_square.move((1, 2))
         test_square.move((1, 2))
 
@@ -253,9 +254,9 @@ class TestTransformationPolygon:
     )
     def test_scale(self):
         good_rectangle_pts = [(0, 0), (2, 0), (2, 3), (0, 3)]
-        good_rectangle = JordanCurve.from_vertices(good_rectangle_pts)
+        good_rectangle = FactoryJordan.polygon(good_rectangle_pts)
         test_rectangle_pts = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        test_rectangle = JordanCurve.from_vertices(test_rectangle_pts)
+        test_rectangle = FactoryJordan.polygon(test_rectangle_pts)
         test_rectangle.scale(2, 3)
         assert test_rectangle == good_rectangle
 
@@ -270,9 +271,9 @@ class TestTransformationPolygon:
     )
     def test_rotate(self):
         good_square_pts = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-        good_square = JordanCurve.from_vertices(good_square_pts)
+        good_square = FactoryJordan.polygon(good_square_pts)
         test_square_pts = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-        test_square = JordanCurve.from_vertices(test_square_pts)
+        test_square = FactoryJordan.polygon(test_square_pts)
 
         assert test_square == good_square
         test_square.rotate(np.pi / 6)  # 30 degrees
@@ -294,9 +295,9 @@ class TestTransformationPolygon:
         orig_square_pts = [(0, 0), (1, 0), (1, 1), (0, 1)]
         inve_square_pts = [(0, 0), (0, 1), (1, 1), (1, 0)]
         test_square_pts = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        orig_square = JordanCurve.from_vertices(orig_square_pts)
-        inve_square = JordanCurve.from_vertices(inve_square_pts)
-        test_square = JordanCurve.from_vertices(test_square_pts)
+        orig_square = FactoryJordan.polygon(orig_square_pts)
+        inve_square = FactoryJordan.polygon(inve_square_pts)
+        test_square = FactoryJordan.polygon(test_square_pts)
 
         assert inve_square != orig_square
         assert test_square == orig_square
@@ -321,8 +322,8 @@ class TestTransformationPolygon:
     )
     def test_split(self):
         square_pts = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-        good_square = JordanCurve.from_vertices(square_pts)
-        test_square = JordanCurve.from_vertices(square_pts)
+        good_square = FactoryJordan.polygon(square_pts)
+        test_square = FactoryJordan.polygon(square_pts)
         test_square.split((0, 2, 3), (0.5, 0.5, 0.5))
         assert test_square == good_square
 
@@ -340,7 +341,7 @@ class TestTransformationPolygon:
     )
     def test_keep_ids(self):
         square_vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        square = JordanCurve.from_vertices(square_vertices)
+        square = FactoryJordan.polygon(square_vertices)
         good_ids = tuple(id(vertex) for vertex in square.vertices)
 
         square.move((2, 3))
@@ -393,14 +394,14 @@ class TestIntegrateJordan:
         for nsides in range(3, 10):
             angles = np.linspace(0, math.tau, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-            jordancurve = JordanCurve.from_vertices(ctrlpoints)
+            jordancurve = FactoryJordan.polygon(ctrlpoints)
             wind = IntegrateJordan.winding_number(jordancurve)
             assert abs(wind - 1) < 1e-9
 
         for nsides in range(3, 10):
             angles = np.linspace(math.tau, 0, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-            jordancurve = JordanCurve.from_vertices(ctrlpoints)
+            jordancurve = FactoryJordan.polygon(ctrlpoints)
             wind = IntegrateJordan.winding_number(jordancurve)
             assert abs(wind + 1) < 1e-9
 
@@ -409,13 +410,13 @@ class TestIntegrateJordan:
     @pytest.mark.dependency(depends=["TestIntegrateJordan::test_begin"])
     def test_lenght_triangle(self):
         vertices = [(0, 0), (3, 0), (0, 4)]
-        jordan_curve = JordanCurve.from_vertices(vertices)
+        jordan_curve = FactoryJordan.polygon(vertices)
         test = float(jordan_curve)
         good = 12
         assert abs(test - good) < 1e-3
 
         vertices = [(0, 0), (0, 4), (3, 0)]
-        jordan_curve = JordanCurve.from_vertices(vertices)
+        jordan_curve = FactoryJordan.polygon(vertices)
         test = float(jordan_curve)
         good = -12
         assert abs(test - good) < 1e-3
@@ -436,7 +437,7 @@ class TestIntegrateJordan:
             (side / 2, side / 2),
             (-side / 2, side / 2),
         ]
-        jordan_curve = JordanCurve.from_vertices(square_vertices)
+        jordan_curve = FactoryJordan.polygon(square_vertices)
         lenght = float(jordan_curve)
         assert lenght > 0
         assert abs(lenght - 4 * side) < 1e-9
@@ -448,7 +449,7 @@ class TestIntegrateJordan:
             (side / 2, side / 2),
             (side / 2, -side / 2),
         ]
-        jordan_curve = JordanCurve.from_vertices(square_vertices)
+        jordan_curve = FactoryJordan.polygon(square_vertices)
         lenght = float(jordan_curve)
         assert lenght < 0
         assert abs(lenght + 4 * side) < 1e-9
@@ -467,7 +468,7 @@ class TestIntegrateJordan:
             lenght = 2 * nsides * np.sin(math.pi / nsides)
             angles = np.linspace(0, math.tau, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-            jordan_curve = JordanCurve.from_vertices(ctrlpoints)
+            jordan_curve = FactoryJordan.polygon(ctrlpoints)
             assert (float(jordan_curve) - lenght) < 1e-9
 
     @pytest.mark.order(15)
@@ -500,12 +501,12 @@ class TestOthers:
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_print(self):
         points = [(1, 1), (2, 2), (0, 3)]
-        triangle = JordanCurve.from_vertices(points)
+        triangle = FactoryJordan.polygon(points)
         str(triangle)
         repr(triangle)
 
         points = [(1.0, 1.0), (2.0, 2.0), (0.0, 3.0)]
-        triangle = JordanCurve.from_vertices(points)
+        triangle = FactoryJordan.polygon(points)
         str(triangle)
         repr(triangle)
 
@@ -515,8 +516,8 @@ class TestOthers:
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_self_intersection(self):
         points = [(0, 0), (1, 0), (0, 1)]
-        jordana = JordanCurve.from_vertices(points)
-        jordanb = JordanCurve.from_vertices(points)
+        jordana = FactoryJordan.polygon(points)
+        jordanb = FactoryJordan.polygon(points)
         assert id(jordana) != id(jordanb)
         inters = jordana & jordanb
         assert not bool(inters)
@@ -541,31 +542,31 @@ class TestOthers:
     @pytest.mark.dependency(depends=["TestOthers::test_begin"])
     def test_clean(self):
         verticesa = [(-1, 0), (0, 0), (1, 0), (0, 1)]
-        jordana = JordanCurve.from_vertices(verticesa)
+        jordana = FactoryJordan.polygon(verticesa)
         jordana = clean_jordan(jordana)
         verticesb = [(-1, 0), (1, 0), (0, 1)]
-        jordanb = JordanCurve.from_vertices(verticesb)
+        jordanb = FactoryJordan.polygon(verticesb)
         assert jordana == jordanb
 
         verticesa = [(-1.0, 0.0), (0.0, 0.0), (1.0, 0.0), (0.0, 1.0)]
-        jordana = JordanCurve.from_vertices(verticesa)
+        jordana = FactoryJordan.polygon(verticesa)
         jordana = clean_jordan(jordana)
         verticesb = [(-1.0, 0.0), (1.0, 0.0), (0.0, 1.0)]
-        jordanb = JordanCurve.from_vertices(verticesb)
+        jordanb = FactoryJordan.polygon(verticesb)
         assert jordana == jordanb
 
         verticesa = [(0, 0), (1, 0), (0, 1), (-1, 0)]
-        jordana = JordanCurve.from_vertices(verticesa)
+        jordana = FactoryJordan.polygon(verticesa)
         jordana = clean_jordan(jordana)
         verticesb = [(-1, 0), (1, 0), (0, 1)]
-        jordanb = JordanCurve.from_vertices(verticesb)
+        jordanb = FactoryJordan.polygon(verticesb)
         assert jordana == jordanb
 
         verticesa = [(0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (-1.0, 0.0)]
-        jordana = JordanCurve.from_vertices(verticesa)
+        jordana = FactoryJordan.polygon(verticesa)
         jordana = clean_jordan(jordana)
         verticesb = [(-1.0, 0.0), (1.0, 0.0), (0.0, 1.0)]
-        jordanb = JordanCurve.from_vertices(verticesb)
+        jordanb = FactoryJordan.polygon(verticesb)
         assert jordana == jordanb
 
     @pytest.mark.order(15)
@@ -574,9 +575,9 @@ class TestOthers:
     )
     def test_equal_divided(self):
         verticesa = [(-1, 0), (1, 0), (0, 1)]
-        jordana = JordanCurve.from_vertices(verticesa)
+        jordana = FactoryJordan.polygon(verticesa)
         verticesb = [(-1, 0), (0, 0), (1, 0), (0, 1)]
-        jordanb = JordanCurve.from_vertices(verticesb)
+        jordanb = FactoryJordan.polygon(verticesb)
         assert jordana == jordanb
 
     @pytest.mark.order(15)


### PR DESCRIPTION
The class `JordanCurve` contains class methods:
* `from_segments`
* `from_vertices`
* `from_ctrlpoints`
* `from_full_curve`

This PR moves these methods to `shapepy.geometry.factory` inside the static class `FactoryJordan`:

* `polygon`
* `spline_curve`