### PR TITLE
Remove `^` and `@` operators for `Point2D` and Analytics in general

### DIFF
--- a/src/shapepy/analytic/base.py
+++ b/src/shapepy/analytic/base.py
@@ -67,10 +67,6 @@ class IAnalytic(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def __matmul__(self, other: Union[Real, IAnalytic]) -> IAnalytic:
-        raise NotImplementedError
-
-    @abstractmethod
     def shift(self, amount: Real) -> IAnalytic:
         """
         Transforms the analytic p(t) into p(t-d) by

--- a/src/shapepy/analytic/bezier.py
+++ b/src/shapepy/analytic/bezier.py
@@ -125,12 +125,6 @@ class Bezier(BaseAnalytic):
         mulpoly = self.__polynomial * other
         return polynomial2bezier(mulpoly)
 
-    def __matmul__(self, other: Union[Real, Polynomial, Bezier]) -> Bezier:
-        if Is.instance(other, Bezier):
-            other = bezier2polynomial(other)
-        matmulpoly = self.__polynomial @ other
-        return polynomial2bezier(matmulpoly)
-
     def __call__(self, node: Real, derivate: int = 0) -> Real:
         node = (node - self.__start) / (self.__end - self.__start)
         return self.__polynomial(node, derivate)

--- a/src/shapepy/analytic/polynomial.py
+++ b/src/shapepy/analytic/polynomial.py
@@ -75,15 +75,6 @@ class Polynomial(BaseAnalytic):
             return self.__class__(coefs, self.domain & other.domain)
         return self.__class__((other * coef for coef in self), self.domain)
 
-    def __matmul__(self, other: Union[Real, Polynomial]) -> Polynomial:
-        if not isinstance(other, Polynomial):
-            return self.__class__((coef @ other for coef in self), self.domain)
-        coefs = [0 * (self[0] @ self[0])] * (self.degree + other.degree + 1)
-        for i, coefi in enumerate(self):
-            for j, coefj in enumerate(other):
-                coefs[i + j] += coefi @ coefj
-        return self.__class__(coefs, self.domain & other.domain)
-
     @vectorize(1, 0)
     def __call__(self, node: Real, derivate: int = 0) -> Real:
         if derivate == 0:
@@ -106,13 +97,6 @@ class Polynomial(BaseAnalytic):
         if self.degree == 0:
             return str(self[0])
         msgs: List[str] = []
-        if not Is.real(self[0]):
-            msgs.append(f"({self[0]})")
-            if self.degree > 0:
-                msgs.append(f"({self[1]}) * t")
-            for i, coef in enumerate(self[2:]):
-                msgs.append(f"({coef}) * t^{i+2}")
-            return " + ".join(msgs)
         flag = False
         for i, coef in enumerate(self):
             if coef == 0:
@@ -135,10 +119,7 @@ class Polynomial(BaseAnalytic):
         """
         Decreases the degree of the bezier curve if possible
         """
-        if Is.real(self[0]):
-            degree = max((i for i, v in enumerate(self) if v), default=0)
-        else:
-            degree = max((i for i, v in enumerate(self) if v @ v), default=0)
+        degree = max((i for i, v in enumerate(self) if v * v > 0), default=0)
         return Polynomial(self[: degree + 1], self.domain)
 
     def scale(self, amount: Real) -> Polynomial:

--- a/src/shapepy/geometry/concatenate.py
+++ b/src/shapepy/geometry/concatenate.py
@@ -9,6 +9,7 @@ import pynurbs
 from ..tools import Is, NotExpectedError, To
 from .base import IParametrizedCurve
 from .piecewise import PiecewiseCurve
+from .point import cross, inner
 from .segment import Segment
 
 
@@ -80,12 +81,12 @@ def bezier_and_bezier(
     dapt = curvea.ctrlpoints[-1] - curvea.ctrlpoints[-2]
     # First point of first derivative
     dbpt = curveb.ctrlpoints[1] - curveb.ctrlpoints[0]
-    if abs(dapt ^ dbpt) > 1e-6:
+    if abs(cross(dapt, dbpt)) > 1e-6:
         node = To.rational(1, 2)
     else:
         dsumpt = dapt + dbpt
-        denomin = dsumpt @ dsumpt
-        node = dapt @ dsumpt / denomin
+        denomin = inner(dsumpt, dsumpt)
+        node = inner(dapt, dsumpt) / denomin
     knotvectora = pynurbs.GeneratorKnotVector.bezier(
         curvea.degree, To.rational
     )

--- a/src/shapepy/geometry/intersection.py
+++ b/src/shapepy/geometry/intersection.py
@@ -29,6 +29,7 @@ from ..tools import Is, NotExpectedError
 from .base import IGeometricCurve, IParametrizedCurve
 from .jordancurve import JordanCurve
 from .piecewise import PiecewiseCurve
+from .point import cross, inner
 from .segment import Segment
 
 
@@ -278,30 +279,30 @@ class IntersectionSegments:
         dA = A1 - A0
         dB = B1 - B0
         B0mA0 = B0 - A0
-        dAxdB = dA ^ dB
+        dAxdB = cross(dA, dB)
         if dAxdB != 0:  # Lines are not parallel
-            t0 = (B0mA0 ^ dB) / dAxdB
+            t0 = cross(B0mA0, dB) / dAxdB
             if t0 < 0 or 1 < t0:
                 return empty, empty
-            u0 = (B0mA0 ^ dA) / dAxdB
+            u0 = cross(B0mA0, dA) / dAxdB
             if u0 < 0 or 1 < u0:
                 return empty, empty
             return SingleValue(t0), SingleValue(u0)
         # Lines are parallel
-        if dA ^ B0mA0 != 0:
+        if cross(dA, B0mA0) != 0:
             return empty, empty  # Parallel, but not colinear
         # Compute the projections
-        dAodA = dA @ dA
-        dBodB = dB @ dB
-        t0 = (B0 - A0) @ dA / dAodA
-        t1 = (B1 - A0) @ dA / dAodA
+        dAodA = inner(dA, dA)
+        dBodB = inner(dB, dB)
+        t0 = inner(B0 - A0, dA) / dAodA
+        t1 = inner(B1 - A0, dA) / dAodA
         if t1 < t0:
             t0, t1 = t1, t0
         if t1 < 0 or 1 < t0:
             return empty, empty
 
-        u0 = (A0 - B0) @ dB / dBodB
-        u1 = (A1 - B0) @ dB / dBodB
+        u0 = inner(A0 - B0, dB) / dBodB
+        u1 = inner(A1 - B0, dB) / dBodB
         if u1 < u0:
             u0, u1 = u1, u0
         t0 = min(max(0, t0), 1)
@@ -338,11 +339,11 @@ class IntersectionSegments:
                 ddv = ddcurveb(v)
 
                 dif = ssu - oov
-                vect0 = dsu @ dif
-                vect1 = -dov @ dif
-                mat00 = dsu @ dsu + ddu @ dif
-                mat01 = -dsu @ dov
-                mat11 = dov @ dov - ddv @ dif
+                vect0 = inner(dsu, dif)
+                vect1 = -inner(dov, dif)
+                mat00 = inner(dsu, dsu) + inner(ddu, dif)
+                mat01 = -inner(dsu, dov)
+                mat11 = inner(dov, dov) - inner(ddv, dif)
                 deter = mat00 * mat11 - mat01**2
                 if abs(deter) < 1e-6:
                     continue

--- a/src/shapepy/geometry/point.py
+++ b/src/shapepy/geometry/point.py
@@ -133,7 +133,7 @@ class Point2D:
 
     def __mul__(self, other: float) -> Point2D:
         if Is.point(other):
-            return self.__matmul__(other)
+            return inner(self, other)
         if not Is.finite(other):
             raise TypeError(f"Multiplication with non-real number: {other}")
         return cartesian(self[0] * other, self[1] * other)
@@ -141,17 +141,9 @@ class Point2D:
     def __rmul__(self, other: float) -> Point2D:
         return self.__mul__(other)
 
-    def __matmul__(self, other: Point2D) -> float:
-        other = To.point(other)
-        return self[0] * other[0] + self[1] * other[1]
-
-    def __xor__(self, other: Point2D) -> float:
-        other = To.point(other)
-        return self[0] * other[1] - self[1] * other[0]
-
     def __abs__(self) -> float:
         """Returns the norm of the point, the distance to the origin"""
-        return Math.sqrt(self @ self)
+        return self.radius
 
     def move(self, vector: tuple[Real, Real]) -> Point2D:
         """
@@ -216,6 +208,16 @@ class Point2D:
         self.__xcoord = x_new
         self.__ycoord = y_new
         return self
+
+
+def inner(pointa: Point2D, pointb: Point2D) -> Real:
+    """Compute the cross product between two points"""
+    return pointa.xcoord * pointb.xcoord + pointa.ycoord * pointb.ycoord
+
+
+def cross(pointa: Point2D, pointb: Point2D) -> Real:
+    """Compute the cross product between two points"""
+    return pointa.xcoord * pointb.ycoord - pointa.ycoord * pointb.xcoord
 
 
 def to_point(point: Point2D | tuple[Real, Real]) -> Point2D:

--- a/tests/analytic/test_bezier.py
+++ b/tests/analytic/test_bezier.py
@@ -399,37 +399,6 @@ def test_split():
 
 
 @pytest.mark.order(4)
-@pytest.mark.dependency(depends=["test_build"])
-def test_numpy_array():
-    degree = 3
-    coefs = np.zeros((degree + 1, 3), dtype="int64")
-    bezier = Bezier(coefs)
-    assert bezier.degree == 3
-    assert tuple(bezier[0]) == (0, 0, 0)
-    assert tuple(bezier[1]) == (0, 0, 0)
-    assert tuple(bezier[2]) == (0, 0, 0)
-    assert tuple(bezier[3]) == (0, 0, 0)
-    str(bezier)
-    repr(bezier)
-
-    coefs = ((3, 2), (-4, 1), (1, -3))
-    coefs = np.array(coefs, dtype="int64")
-    bezier = Bezier(coefs)
-    assert bezier.degree == 2
-    assert tuple(bezier[0]) == (3, 2)
-    assert tuple(bezier[1]) == (-4, 1)
-    assert tuple(bezier[2]) == (1, -3)
-    str(bezier)
-    repr(bezier)
-
-    square = bezier @ bezier
-    assert square.degree == 4
-    assert square == Bezier([13, -10, frac(31, 3), -7, 10])
-    point = np.array([2, 1], dtype="int64")
-    assert bezier @ point == Bezier([8, -7, -1])
-
-
-@pytest.mark.order(4)
 @pytest.mark.dependency(
     depends=[
         "test_build",
@@ -448,7 +417,6 @@ def test_numpy_array():
         "test_shift",
         "test_clean",
         "test_split",
-        "test_numpy_array",
     ]
 )
 def test_all():

--- a/tests/analytic/test_polynomial.py
+++ b/tests/analytic/test_polynomial.py
@@ -320,41 +320,6 @@ def test_print():
 
 
 @pytest.mark.order(3)
-@pytest.mark.dependency(depends=["test_build"])
-def test_numpy_array():
-    degree = 3
-    coefs = np.zeros((degree + 1, 3), dtype="int64")
-    poly = Polynomial(coefs)
-    assert poly.degree == 3
-    assert tuple(poly[0]) == (0, 0, 0)
-    assert tuple(poly[1]) == (0, 0, 0)
-    assert tuple(poly[2]) == (0, 0, 0)
-    assert tuple(poly[3]) == (0, 0, 0)
-    assert poly.clean().degree == 0
-    str(poly)
-    repr(poly)
-
-    coefs = ((3, 2), (-4, 1), (1, -3))
-    coefs = np.array(coefs, dtype="int64")
-    poly = Polynomial(coefs)
-    assert poly.degree == 2
-    assert tuple(poly[0]) == (3, 2)
-    assert tuple(poly[1]) == (-4, 1)
-    assert tuple(poly[2]) == (1, -3)
-    str(poly)
-    repr(poly)
-
-    coefs = np.array(coefs, dtype="int64")
-    poly = Polynomial(coefs)
-    assert poly.degree == 2
-    square = poly @ poly
-    assert square.degree == 4
-    assert square == Polynomial([13, -20, 11, -14, 10])
-    point = np.array([2, 1], dtype="int64")
-    assert poly @ point == Polynomial([8, -7, -1])
-
-
-@pytest.mark.order(3)
 @pytest.mark.dependency(depends=["test_evaluate"])
 def test_infinity_evaluation():
     for const in range(-10, 11):
@@ -394,7 +359,6 @@ def test_infinity_evaluation():
         "test_pow",
         "test_shift",
         "test_scale",
-        "test_numpy_array",
         "test_infinity_evaluation",
     ]
 )

--- a/tests/geometry/test_point.py
+++ b/tests/geometry/test_point.py
@@ -6,7 +6,7 @@ from fractions import Fraction as frac
 
 import pytest
 
-from shapepy.geometry.point import cartesian, polar
+from shapepy.geometry.point import cartesian, cross, inner, polar
 from shapepy.scalar.angle import Angle
 
 
@@ -306,18 +306,18 @@ def test_norm():
 def test_inner():
     pointa = cartesian(0, 0)
     pointb = cartesian(0, 0)
-    assert pointa @ pointb == 0
-    assert pointb @ pointa == 0
+    assert inner(pointa, pointb) == 0
+    assert inner(pointb, pointa) == 0
 
     pointa = cartesian(1, 0)
     pointb = cartesian(0, 1)
-    assert pointa @ pointb == 0
-    assert pointb @ pointa == 0
+    assert inner(pointa, pointb) == 0
+    assert inner(pointb, pointa) == 0
 
     pointa = cartesian(1, 1)
     pointb = cartesian(1, 1)
-    assert pointa @ pointb == 2
-    assert pointb @ pointa == 2
+    assert inner(pointa, pointb) == 2
+    assert inner(pointb, pointa) == 2
 
 
 @pytest.mark.order(11)
@@ -328,18 +328,18 @@ def test_inner():
 def test_cross():
     pointa = cartesian(0, 0)
     pointb = cartesian(0, 0)
-    assert pointa ^ pointb == 0
-    assert pointb ^ pointa == 0
+    assert cross(pointa, pointb) == 0
+    assert cross(pointb, pointa) == 0
 
     pointa = cartesian(1, 0)
     pointb = cartesian(0, 1)
-    assert pointa ^ pointb == 1
-    assert pointb ^ pointa == -1
+    assert cross(pointa, pointb) == 1
+    assert cross(pointb, pointa) == -1
 
     pointa = cartesian(1, 1)
     pointb = cartesian(1, 1)
-    assert pointa ^ pointb == 0
-    assert pointb ^ pointa == 0
+    assert cross(pointa, pointb) == 0
+    assert cross(pointb, pointa) == 0
 
 
 @pytest.mark.order(11)
@@ -354,13 +354,12 @@ def test_cross():
     ]
 )
 def test_equivalent_expression():
-    return
     pta = cartesian(frac(5, 13), frac(12, 13))
     ptb = cartesian(frac(3, 5), frac(4, 5))
-    assert pta * ptb == pta[0] * ptb[0] + pta[1] * ptb[1]
-    assert ptb * pta == pta[0] * ptb[0] + pta[1] * ptb[1]
-    assert pta ^ ptb == pta[0] * ptb[1] - pta[1] * ptb[0]
-    assert ptb ^ pta == pta[0] * ptb[1] - pta[1] * ptb[0]
+    assert inner(pta, ptb) == pta[0] * ptb[0] + pta[1] * ptb[1]
+    assert inner(ptb, pta) == pta[0] * ptb[0] + pta[1] * ptb[1]
+    assert cross(pta, ptb) == pta[0] * ptb[1] - pta[1] * ptb[0]
+    assert cross(ptb, pta) == pta[1] * ptb[0] - pta[0] * ptb[1]
 
 
 @pytest.mark.order(11)


### PR DESCRIPTION
The operators `^` and `@` were removed:

* For `Point2D`
    * `A ^ B` presented as the cross product between `A` and `B`. The function `cross(A, B)` takes its place
    * `A @ B` presented as the inner product between `A` and `B`. The function `inner(A, B)` takes its place
* For `Polynomial` and `Bezier`
    * The `@` presented the inner multiplication between two analytic functions. As the coefficients of a polynomial can also be `Point2D` (cause they support linear operation), then `p(t) @ p(t)` returned another polynomial function which coefficients were scalar.