### PR TITLE
Remove cast operations for bool2d instances

### DIFF
--- a/docs/source/rst/theory.rst
+++ b/docs/source/rst/theory.rst
@@ -689,7 +689,7 @@ For example, the first good information from the table is given by:
     shapea = SimpleShape(jordana)
     shapeb = SimpleShape(jordanb) 
     # Decide if shapea in shapeb
-    if float(shapea) < 0 and float(shapeb) > 0:
+    if shapea.area < 0 and shapeb.area > 0:
         # For any presented cases it happens
         return False
     # continue ...
@@ -715,7 +715,7 @@ For example, the first good information from the table is given by:
 .. code-block:: python
 
     # ... continue
-    if float(shapea) > 0 and float(shapeb) < 0:
+    if shapea.area > 0 and shapeb.area < 0:
         # Only for case 1
         return (jordana in shapeb) and (jordanb not in shapea)
     # continue ...
@@ -765,7 +765,7 @@ Taking out the already extracted values, and separating by when ``areaA > areaB`
 .. code-block:: python
 
     # ... continue
-    if float(shapea) > float(shapeb):
+    if shapea.area > shapeb.area:
         return False
     # continue ...
 

--- a/src/shapepy/bool2d/base.py
+++ b/src/shapepy/bool2d/base.py
@@ -61,9 +61,8 @@ class SubSetR2:
         """XOR of SubSetR2"""
         return (self - other) | (other - self)
 
-    def __bool__(self) -> bool:
-        """Area is positive ?"""
-        return float(self) > 0
+    def __repr__(self) -> str:  # pragma: no cover
+        return str(self)
 
 
 class EmptyShape(SubSetR2):
@@ -103,9 +102,6 @@ class EmptyShape(SubSetR2):
     def __sub__(self, other: SubSetR2) -> SubSetR2:
         return self
 
-    def __float__(self) -> float:
-        return float(0)
-
     def __invert__(self) -> SubSetR2:
         return WholeShape()
 
@@ -115,8 +111,8 @@ class EmptyShape(SubSetR2):
     def __str__(self) -> str:
         return "EmptyShape"
 
-    def __repr__(self) -> str:
-        return self.__str__()
+    def __bool__(self) -> bool:
+        return False
 
 
 class WholeShape(SubSetR2):
@@ -153,9 +149,6 @@ class WholeShape(SubSetR2):
     def __and__(self, other: SubSetR2) -> SubSetR2:
         return copy(other)
 
-    def __float__(self) -> float:
-        return float("inf")
-
     def __invert__(self) -> SubSetR2:
         return EmptyShape()
 
@@ -165,11 +158,11 @@ class WholeShape(SubSetR2):
     def __str__(self) -> str:
         return "WholeShape"
 
-    def __repr__(self) -> str:
-        return self.__str__()
-
     def __sub__(self, other: SubSetR2) -> SubSetR2:
         return ~other
+
+    def __bool__(self) -> bool:
+        return True
 
 
 class Future:

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -277,11 +277,10 @@ class SimpleShape(DefinedShape):
         return SimpleShape(copy(self.__jordancurve))
 
     def __str__(self) -> str:
-        vertices = self.jordans[0].vertices
-        vertices = tuple(tuple(vertex) for vertex in vertices)
-        msg = f"Simple Shape of area {self.area:.2f} with vertices:\n"
-        msg += str(np.array(vertices, dtype="float64"))
-        return msg
+        area = float(self.area)
+        vertices = tuple(map(tuple, self.jordans[0].vertices))
+        vertices = np.array(vertices, dtype="float64")
+        return f"Simple Shape of area {area:.2f} with vertices:\n{vertices}"
 
     def __repr__(self) -> str:
         area, vertices = self.area, self.jordans[0].vertices

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -283,7 +283,7 @@ class SimpleShape(DefinedShape):
         return f"Simple Shape of area {area:.2f} with vertices:\n{vertices}"
 
     def __repr__(self) -> str:
-        area, vertices = self.area, self.jordans[0].vertices
+        area, vertices = float(self.area), self.jordans[0].vertices
         msg = f"Simple shape of area {area:.2f} with {len(vertices)} vertices"
         return msg
 

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -282,11 +282,6 @@ class SimpleShape(DefinedShape):
         vertices = np.array(vertices, dtype="float64")
         return f"Simple Shape of area {area:.2f} with vertices:\n{vertices}"
 
-    def __repr__(self) -> str:
-        area, vertices = float(self.area), self.jordans[0].vertices
-        msg = f"Simple shape of area {area:.2f} with {len(vertices)} vertices"
-        return msg
-
     def __eq__(self, other: SubSetR2) -> bool:
         """Compare two shapes
 
@@ -448,9 +443,6 @@ class ConnectedShape(DefinedShape):
     def __str__(self) -> str:
         return f"Connected shape total area {self.area}"
 
-    def __repr__(self) -> str:
-        return str(self)
-
     def __eq__(self, other: SubSetR2) -> bool:
         assert Is.instance(other, SubSetR2)
         return (
@@ -599,9 +591,6 @@ class DisjointShape(DefinedShape):
         msg = f"Disjoint shape with total area {self.area} and "
         msg += f"{len(self.subshapes)} subshapes"
         return msg
-
-    def __repr__(self) -> str:
-        return self.__str__()
 
     def _contains_point(
         self, point: Point2D, boundary: Optional[bool] = True

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -20,6 +20,7 @@ from ..geometry.box import Box
 from ..geometry.integral import IntegrateJordan
 from ..geometry.jordancurve import JordanCurve
 from ..geometry.point import Point2D
+from ..scalar.reals import Real
 from ..tools import Is, To
 from .base import EmptyShape, SubSetR2
 
@@ -70,9 +71,6 @@ class DefinedShape(SubSetR2):
             return self.contains_jordan(other)
         point = To.point(other)
         return self.contains_point(point)
-
-    def __float__(self) -> float:
-        return float(sum(jordan.area for jordan in self.jordans))
 
     def move(self, point: Point2D) -> SubSetR2:
         """
@@ -279,15 +277,14 @@ class SimpleShape(DefinedShape):
         return SimpleShape(copy(self.__jordancurve))
 
     def __str__(self) -> str:
-        area = float(self)
         vertices = self.jordans[0].vertices
         vertices = tuple(tuple(vertex) for vertex in vertices)
-        msg = f"Simple Shape of area {area:.2f} with vertices:\n"
+        msg = f"Simple Shape of area {self.area:.2f} with vertices:\n"
         msg += str(np.array(vertices, dtype="float64"))
         return msg
 
     def __repr__(self) -> str:
-        area, vertices = float(self), self.jordans[0].vertices
+        area, vertices = self.area, self.jordans[0].vertices
         msg = f"Simple shape of area {area:.2f} with {len(vertices)} vertices"
         return msg
 
@@ -303,14 +300,19 @@ class SimpleShape(DefinedShape):
         """
         if not Is.instance(other, SubSetR2):
             raise ValueError
-        if not Is.instance(other, SimpleShape):
-            return False
-        if float(self) != float(other):
-            return False
-        return self.__jordancurve == other.jordans[0]
+        return (
+            Is.instance(other, SimpleShape)
+            and self.area == other.area
+            and self.__jordancurve == other.jordans[0]
+        )
 
     def __invert__(self) -> SimpleShape:
         return self.__class__(~self.__jordancurve)
+
+    @property
+    def area(self) -> Real:
+        """The internal area that is enclosed by the shape"""
+        return self.__jordancurve.area
 
     @property
     def jordans(self) -> Tuple[JordanCurve]:
@@ -357,9 +359,11 @@ class SimpleShape(DefinedShape):
     ) -> bool:
         jordan = self.jordans[0]
         wind = IntegrateJordan.winding_number(jordan, center=point)
-        if float(jordan) > 0:
-            return wind > 0 if boundary else wind == 1
-        return wind > -1 if boundary else wind == 0
+        return (
+            (wind > 0 if boundary else wind == 1)
+            if jordan.area > 0
+            else wind > -1 if boundary else wind == 0
+        )
 
     def _contains_jordan(
         self, jordan: JordanCurve, boundary: Optional[bool] = True
@@ -403,8 +407,8 @@ class SimpleShape(DefinedShape):
     # pylint: disable=chained-comparison
     def __contains_simple(self, other: SimpleShape) -> bool:
         assert Is.instance(other, SimpleShape)
-        areaa = float(other)
-        areab = float(self)
+        areaa = other.area
+        areab = self.area
         jordana = other.jordans[0]
         jordanb = self.jordans[0]
         if areaa < 0 and areab > 0:
@@ -437,23 +441,23 @@ class ConnectedShape(DefinedShape):
         simples = tuple(map(copy, self.subshapes))
         return ConnectedShape(simples)
 
-    def __float__(self) -> float:
-        return sum(map(float, self.subshapes))
+    @property
+    def area(self) -> Real:
+        """The internal area that is enclosed by the shape"""
+        return sum(simple.area for simple in self.subshapes)
 
     def __str__(self) -> str:
-        msg = f"Connected shape total area {float(self)}"
-        return msg
+        return f"Connected shape total area {self.area}"
 
     def __repr__(self) -> str:
         return str(self)
 
     def __eq__(self, other: SubSetR2) -> bool:
         assert Is.instance(other, SubSetR2)
-        if not Is.instance(other, ConnectedShape):
-            return False
-        if abs(float(self) - float(other)) > 1e-6:
-            return False
-        return True
+        return (
+            Is.instance(other, ConnectedShape)
+            and abs(self.area - other.area) < 1e-6
+        )
 
     def __invert__(self) -> DisjointShape:
         simples = [~simple for simple in self.subshapes]
@@ -500,17 +504,17 @@ class ConnectedShape(DefinedShape):
         return self.__subshapes
 
     @subshapes.setter
-    def subshapes(self, values: Tuple[SimpleShape]):
-        for value in values:
-            assert Is.instance(value, SimpleShape)
-        areas = map(float, values)
+    def subshapes(self, simples: Tuple[SimpleShape]):
+        if not all(Is.instance(simple, SimpleShape) for simple in simples):
+            raise TypeError
+        areas = (simple.area for simple in simples)
 
         def algori(pair):
             return pair[0]
 
-        values = sorted(zip(areas, values), key=algori, reverse=True)
-        values = tuple(val[1] for val in values)
-        self.__subshapes = tuple(values)
+        simples = sorted(zip(areas, simples), key=algori, reverse=True)
+        simples = tuple(val[1] for val in simples)
+        self.__subshapes = tuple(simples)
 
     def _contains_point(
         self, point: Point2D, boundary: Optional[bool] = True
@@ -568,17 +572,16 @@ class DisjointShape(DefinedShape):
         new_jordans = tuple(~jordan for jordan in self.jordans)
         return shape_from_jordans(new_jordans)
 
-    def __float__(self) -> float:
-        total = 0
-        for subshape in self.subshapes:
-            total += float(subshape)
-        return float(total)
+    @property
+    def area(self) -> Real:
+        """The internal area that is enclosed by the shape"""
+        return sum(sub.area for sub in self.subshapes)
 
     def __eq__(self, other: SubSetR2):
         assert Is.instance(other, SubSetR2)
         if not Is.instance(other, DisjointShape):
             return False
-        if float(self) != float(other):
+        if self.area != other.area:
             return False
         self_subshapes = list(self.subshapes)
         othe_subshapes = list(other.subshapes)
@@ -594,7 +597,7 @@ class DisjointShape(DefinedShape):
         return not (len(self_subshapes) or len(othe_subshapes))
 
     def __str__(self) -> str:
-        msg = f"Disjoint shape with total area {float(self)} and "
+        msg = f"Disjoint shape with total area {self.area} and "
         msg += f"{len(self.subshapes)} subshapes"
         return msg
 
@@ -676,10 +679,12 @@ class DisjointShape(DefinedShape):
 
     @subshapes.setter
     def subshapes(self, values: Tuple[SubSetR2]):
-        for value in values:
-            assert Is.instance(value, (SimpleShape, ConnectedShape))
-        areas = map(float, values)
-        lenghts = map(float, [val.jordans[0] for val in values])
+        if not all(
+            Is.instance(sub, (SimpleShape, ConnectedShape)) for sub in values
+        ):
+            raise ValueError
+        areas = tuple(sub.area for sub in values)
+        lenghts = tuple(sub.jordans[0].length for sub in values)
 
         def algori(triple):
             return triple[:2]
@@ -706,7 +711,7 @@ def divide_connecteds(
     connected = []
     simples = list(simples)
     while len(simples) != 0:
-        areas = map(float, simples)
+        areas = (s.area for s in simples)
         absareas = tuple(map(abs, areas))
         index = absareas.index(max(absareas))
         connected.append(simples.pop(index))

--- a/src/shapepy/geometry/integral.py
+++ b/src/shapepy/geometry/integral.py
@@ -91,7 +91,7 @@ class IntegrateJordan:
         if center in jordan.box():
             for bezier in jordan.segments:
                 if center in bezier:
-                    return 0.5 if float(jordan) > 0 else -0.5
+                    return 0.5 if jordan.area > 0 else -0.5
         for bezier in jordan.segments:
             wind += IntegrateSegment.winding_number(bezier, center, nnodes)
         return round(wind)

--- a/src/shapepy/geometry/jordancurve.py
+++ b/src/shapepy/geometry/jordancurve.py
@@ -350,30 +350,6 @@ class JordanCurve(IGeometricCurve):
         """Tells if the point is on the boundary"""
         return point in self.piecewise
 
-    def __float__(self) -> float:
-        """Returns the lenght of the curve
-
-        If jordan curve is clockwise, then lenght < 0
-
-        :getter: Returns the total lenght of the jordan curve
-        :type: float
-
-        Example use
-        -----------
-
-        >>> from shapepy import JordanCurve
-        >>> vertices = [(0, 0), (4, 0), (0, 3)]
-        >>> jordan = FactoryJordan.polygon(vertices)
-        >>> print(float(jordan))
-        12.0
-        >>> vertices = [(0, 0), (0, 3), (4, 0)]
-        >>> jordan = FactoryJordan.polygon(vertices)
-        >>> print(float(jordan))
-        -12.0
-
-        """
-        return float(self.length if self.area > 0 else -self.length)
-
 
 def compute_area(jordan: JordanCurve) -> Real:
     """

--- a/src/shapepy/plot/plot.py
+++ b/src/shapepy/plot/plot.py
@@ -161,7 +161,7 @@ class ShapePloter:
         )
         for connected in connecteds:
             path = path_shape(connected)
-            if float(connected) > 0:
+            if connected.area > 0:
                 patch = PathPatch(path, color=fill_color, alpha=alpha)
             else:
                 self.gca().set_facecolor("#BFFFBF")
@@ -169,7 +169,7 @@ class ShapePloter:
             self.gca().add_patch(patch)
             for jordan in connected.jordans:
                 path = path_jordan(jordan)
-                color = pos_color if float(jordan) > 0 else neg_color
+                color = pos_color if jordan.area > 0 else neg_color
                 patch = PathPatch(
                     path, edgecolor=color, facecolor="none", lw=2
                 )

--- a/tests/bool2d/test_bool_finite_intersect.py
+++ b/tests/bool2d/test_bool_finite_intersect.py
@@ -42,8 +42,8 @@ class TestIntersectionSimple:
         square0 = Primitive.regular_polygon(nsides=4, radius=2, center=(-1, 0))
         square1 = Primitive.regular_polygon(nsides=4, radius=2, center=(1, 0))
 
-        assert float(square0) > 0
-        assert float(square1) > 0
+        assert square0.area > 0
+        assert square1.area > 0
 
         good_points = [(0, 1), (-1, 2), (-3, 0), (-1, -2)]
         good_points += [(0, -1), (1, -2), (3, 0), (1, 2)]

--- a/tests/bool2d/test_bool_no_intersect.py
+++ b/tests/bool2d/test_bool_no_intersect.py
@@ -38,7 +38,7 @@ class TestEqualSquare:
     @pytest.mark.dependency(depends=["TestEqualSquare::test_begin"])
     def test_or(self):
         square = Primitive.square(side=1, center=(0, 0))
-        assert float(square) > 0
+        assert square.area > 0
         assert square | square == square
         assert square | (~square) is WholeShape()
         assert (~square) | square is WholeShape()
@@ -51,7 +51,7 @@ class TestEqualSquare:
     )
     def test_and(self):
         square = Primitive.square(side=1, center=(0, 0))
-        assert float(square) > 0
+        assert square.area > 0
         assert square & square == square
         assert square & (~square) is EmptyShape()
         assert (~square) & square is EmptyShape()
@@ -67,7 +67,7 @@ class TestEqualSquare:
     )
     def test_sub(self):
         square = Primitive.square(side=1, center=(0, 0))
-        assert float(square) > 0
+        assert square.area > 0
         assert square - square is EmptyShape()
         assert square - (~square) == square
         assert (~square) - square == ~square
@@ -85,7 +85,7 @@ class TestEqualSquare:
     )
     def test_xor(self):
         square = Primitive.square(side=1, center=(0, 0))
-        assert float(square) > 0
+        assert square.area > 0
         assert square ^ square is EmptyShape()
         assert square ^ (~square) is WholeShape()
         assert (~square) ^ square is WholeShape()
@@ -126,8 +126,8 @@ class TestTwoCenteredSquares:
     def test_or(self):
         square1 = Primitive.square(side=1)
         square2 = Primitive.square(side=2)
-        assert float(square1) > 0
-        assert float(square2) > 0
+        assert square1.area > 0
+        assert square2.area > 0
 
         assert square1 | square2 == square2
         assert square2 | square1 == square2
@@ -144,8 +144,8 @@ class TestTwoCenteredSquares:
     def test_and(self):
         square1 = Primitive.square(side=1)
         square2 = Primitive.square(side=2)
-        assert float(square1) > 0
-        assert float(square2) > 0
+        assert square1.area > 0
+        assert square2.area > 0
 
         assert square1 & square2 == square1
         assert square2 & square1 == square1
@@ -162,8 +162,8 @@ class TestTwoCenteredSquares:
     def test_sub(self):
         square1 = Primitive.square(side=1)
         square2 = Primitive.square(side=2)
-        assert float(square1) > 0
-        assert float(square2) > 0
+        assert square1.area > 0
+        assert square2.area > 0
 
         assert square1 - square2 is EmptyShape()
         assert square2 - square1 == ConnectedShape([square2, ~square1])
@@ -180,8 +180,8 @@ class TestTwoCenteredSquares:
     def test_xor(self):
         square1 = Primitive.square(side=1)
         square2 = Primitive.square(side=2)
-        assert float(square1) > 0
-        assert float(square2) > 0
+        assert square1.area > 0
+        assert square2.area > 0
 
         assert square1 ^ square2 == ConnectedShape([square2, ~square1])
         assert square2 ^ square1 == ConnectedShape([square2, ~square1])
@@ -230,8 +230,8 @@ class TestTwoDisjointSquares:
     def test_or(self):
         left = Primitive.square(side=2, center=(-2, 0))
         right = Primitive.square(side=2, center=(2, 0))
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left | right == DisjointShape([left, right])
         assert right | left == DisjointShape([left, right])
@@ -248,8 +248,8 @@ class TestTwoDisjointSquares:
     def test_and(self):
         left = Primitive.square(side=2, center=(-2, 0))
         right = Primitive.square(side=2, center=(2, 0))
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left & right is EmptyShape()
         assert right & left is EmptyShape()
@@ -266,8 +266,8 @@ class TestTwoDisjointSquares:
     def test_sub(self):
         left = Primitive.square(side=2, center=(-2, 0))
         right = Primitive.square(side=2, center=(2, 0))
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left - right == left
         assert right - left == right
@@ -284,8 +284,8 @@ class TestTwoDisjointSquares:
     def test_xor(self):
         left = Primitive.square(side=1, center=(-2, 0))
         right = Primitive.square(side=1, center=(2, 0))
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left ^ right == DisjointShape([left, right])
         assert right ^ left == DisjointShape([left, right])
@@ -327,7 +327,7 @@ class TestEqualHollowSquare:
         big = Primitive.square(side=2, center=(0, 0))
         small = Primitive.square(side=1, center=(0, 0))
         square = big - small
-        assert float(square) > 0
+        assert square.area > 0
         assert square | square == square
         assert square | (~square) is WholeShape()
         assert (~square) | square is WholeShape()
@@ -345,7 +345,7 @@ class TestEqualHollowSquare:
         big = Primitive.square(side=2, center=(0, 0))
         small = Primitive.square(side=1, center=(0, 0))
         square = big - small
-        assert float(square) > 0
+        assert square.area > 0
         assert square & square == square
         assert square & (~square) is EmptyShape()
         assert (~square) & square is EmptyShape()
@@ -363,7 +363,7 @@ class TestEqualHollowSquare:
         big = Primitive.square(side=2, center=(0, 0))
         small = Primitive.square(side=1, center=(0, 0))
         square = big - small
-        assert float(square) > 0
+        assert square.area > 0
         assert square - square is EmptyShape()
         assert square - (~square) == square
         assert (~square) - square == ~square
@@ -383,7 +383,7 @@ class TestEqualHollowSquare:
         big = Primitive.square(side=2, center=(0, 0))
         small = Primitive.square(side=1, center=(0, 0))
         square = big - small
-        assert float(square) > 0
+        assert square.area > 0
         assert square ^ square is EmptyShape()
         assert square ^ (~square) is WholeShape()
         assert (~square) ^ square is WholeShape()
@@ -434,8 +434,8 @@ class TestTwoDisjHollowSquares:
         right_sma = Primitive.square(side=1, center=(2, 0))
         left = left_big - left_sma
         right = right_big - right_sma
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left | right == DisjointShape([left, right])
         assert right | left == DisjointShape([left, right])
@@ -456,8 +456,8 @@ class TestTwoDisjHollowSquares:
         right_sma = Primitive.square(side=1, center=(2, 0))
         left = left_big - left_sma
         right = right_big - right_sma
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left & right is EmptyShape()
         assert right & left is EmptyShape()
@@ -480,8 +480,8 @@ class TestTwoDisjHollowSquares:
         right_sma = Primitive.square(side=1, center=(2, 0))
         left = left_big - left_sma
         right = right_big - right_sma
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left - right == left
         assert right - left == right
@@ -504,8 +504,8 @@ class TestTwoDisjHollowSquares:
         right_sma = Primitive.square(side=1, center=(2, 0))
         left = left_big - left_sma
         right = right_big - right_sma
-        assert float(left) > 0
-        assert float(right) > 0
+        assert left.area > 0
+        assert right.area > 0
 
         assert left ^ right == DisjointShape([left, right])
         assert right ^ left == DisjointShape([left, right])

--- a/tests/bool2d/test_empty_whole.py
+++ b/tests/bool2d/test_empty_whole.py
@@ -93,14 +93,6 @@ class TestBoolean:
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_float(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert float(empty) == float(0)
-        assert float(whole) == float("inf")
-
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
     def test_invert(self):
         empty = EmptyShape()
         whole = WholeShape()
@@ -126,7 +118,6 @@ class TestBoolean:
             "TestBoolean::test_xor",
             "TestBoolean::test_sub",
             "TestBoolean::test_bool",
-            "TestBoolean::test_float",
             "TestBoolean::test_invert",
             "TestBoolean::test_copy",
         ]
@@ -154,7 +145,7 @@ class TestBoolShape:
         whole = WholeShape()
         vertices = [(0, 0), (1, 0), (0, 1)]
         shape = Primitive.polygon(vertices)
-        assert float(shape) > 0
+        assert shape.area > 0
 
         # OR
         assert shape | empty == shape
@@ -188,7 +179,7 @@ class TestBoolShape:
         whole = WholeShape()
         vertices = [(0, 0), (0, 1), (1, 0)]
         shape = Primitive.polygon(vertices)
-        assert float(shape) < 0
+        assert shape.area < 0
         assert shape | empty == shape
         assert shape | whole is whole
 

--- a/tests/bool2d/test_primitive.py
+++ b/tests/bool2d/test_primitive.py
@@ -65,20 +65,16 @@ class TestPrimitive:
     )
     def test_square(self):
         square = Primitive.square()
-        area = 1
-        assert abs(float(square) - area) < 1e-9
+        assert abs(square.area - 1) < 1e-9
 
         square = Primitive.square(side=2)
-        area = 4
-        assert abs(float(square) - area) < 1e-9
+        assert abs(square.area - 4) < 1e-9
 
         square = Primitive.square(side=4)
-        area = 16
-        assert abs(float(square) - area) < 1e-9
+        assert abs(square.area - 16) < 1e-9
 
         square = Primitive.square(side=3, center=(1, 2))
-        area = 9
-        assert abs(float(square) - area) < 1e-9
+        assert abs(square.area - 9) < 1e-9
 
     @pytest.mark.order(22)
     @pytest.mark.timeout(10)
@@ -93,13 +89,13 @@ class TestPrimitive:
         for nsides in range(3, 10):
             polygon = Primitive.regular_polygon(nsides)
             area = nsides * math.sin(2 * math.pi / nsides) / 2
-            assert abs(float(polygon) - area) < 1e-9
+            assert abs(polygon.area - area) < 1e-9
 
         radius = 4
         for nsides in range(3, 10):
             polygon = Primitive.regular_polygon(nsides, radius=radius)
             area = radius**2 * nsides * math.sin(2 * math.pi / nsides) / 2
-            assert abs(float(polygon) - area) < 1e-9
+            assert abs(polygon.area - area) < 1e-9
 
     @pytest.mark.order(22)
     @pytest.mark.timeout(10)
@@ -114,13 +110,11 @@ class TestPrimitive:
     def test_polygon(self):
         points = [(0, 0), (1, 0), (0, 1)]
         triangle = Primitive.polygon(points)
-        area = 0.5
-        assert abs(float(triangle) - area) < 1e-9
+        assert triangle.area == 1 / 2
 
         points = [(0, 0), (0, 1), (1, 0)]
         triangle = Primitive.polygon(points)
-        area = -0.5
-        assert abs(float(triangle) - area) < 1e-9
+        assert triangle.area == -1 / 2
 
     @pytest.mark.order(22)
     @pytest.mark.timeout(10)
@@ -135,13 +129,11 @@ class TestPrimitive:
     )
     def test_circle(self):
         circle = Primitive.circle()
-        area = math.pi
-        assert abs(float(circle) - area) < 1e-3
+        assert abs(circle.area - math.pi) < 1e-3
 
         radius = 5
         circle = Primitive.circle(radius=radius)
-        area = math.pi * radius**2
-        assert abs(float(circle) - area) < 1e-3 * radius**2
+        assert abs(circle.area - math.pi * radius**2) < 1e-3 * radius**2
 
     @pytest.mark.order(22)
     @pytest.mark.timeout(10)

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -424,15 +424,13 @@ class TestIntegrateJordan:
     def test_lenght_triangle(self):
         vertices = [(0, 0), (3, 0), (0, 4)]
         jordan_curve = FactoryJordan.polygon(vertices)
-        test = float(jordan_curve)
-        good = 12
-        assert abs(test - good) < 1e-3
+        assert jordan_curve.length == 12
+        assert jordan_curve.area == 6
 
         vertices = [(0, 0), (0, 4), (3, 0)]
         jordan_curve = FactoryJordan.polygon(vertices)
-        test = float(jordan_curve)
-        good = -12
-        assert abs(test - good) < 1e-3
+        assert jordan_curve.length == 12
+        assert jordan_curve.area == -6
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)
@@ -451,9 +449,8 @@ class TestIntegrateJordan:
             (-side / 2, side / 2),
         ]
         jordan_curve = FactoryJordan.polygon(square_vertices)
-        lenght = float(jordan_curve)
-        assert lenght > 0
-        assert abs(lenght - 4 * side) < 1e-9
+        assert jordan_curve.length == 4 * side
+        assert jordan_curve.area == side * side
 
         side = 3
         square_vertices = [
@@ -463,9 +460,8 @@ class TestIntegrateJordan:
             (side / 2, -side / 2),
         ]
         jordan_curve = FactoryJordan.polygon(square_vertices)
-        lenght = float(jordan_curve)
-        assert lenght < 0
-        assert abs(lenght + 4 * side) < 1e-9
+        assert jordan_curve.length == 4 * side
+        assert jordan_curve.area == -side * side
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)
@@ -479,10 +475,12 @@ class TestIntegrateJordan:
     def test_lenght_regular_polygon(self):
         for nsides in range(3, 10):
             lenght = 2 * nsides * np.sin(math.pi / nsides)
+            area = nsides * np.sin(2 * math.pi / nsides) / 2
             angles = np.linspace(0, math.tau, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
             jordan_curve = FactoryJordan.polygon(ctrlpoints)
-            assert (float(jordan_curve) - lenght) < 1e-9
+            assert abs(jordan_curve.length - lenght) < 1e-15
+            assert abs(jordan_curve.area - area) < 1e-15
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)


### PR DESCRIPTION
This PR removes the operators `__float__` for the classes
* `JordanCurve`: Use `length` property instead
* `SimpleShape`: Use `area` property instead
* `ConnectedShape`: Use `area` property instead
* `DisjoinShape`: Use `area` property instead

Also removes `__bool__` for `SubSetR2`.
Only `EmptyShape` and `WholeShape` contains this cast operation