### PR TITLE
Feat: create `USegment`, which doesn't matter their parameters

### DIFF
--- a/src/shapepy/bool2d/primitive.py
+++ b/src/shapepy/bool2d/primitive.py
@@ -16,6 +16,7 @@ from ..geometry.factory import FactoryJordan
 from ..geometry.jordancurve import JordanCurve
 from ..geometry.point import Point2D, cartesian
 from ..geometry.segment import Segment
+from ..geometry.unparam import USegment
 from ..tools import Is, To
 from .base import EmptyShape, WholeShape
 from .shape import SimpleShape
@@ -236,7 +237,7 @@ class Primitive:
         new_bezier = Segment([start_point, middle_point, end_point])
         beziers.append(new_bezier)
 
-        jordan_curve = JordanCurve(beziers)
+        jordan_curve = JordanCurve(map(USegment, beziers))
         jordan_curve.move(center)
         circle = SimpleShape(jordan_curve)
         return circle

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -362,7 +362,7 @@ class SimpleShape(DefinedShape):
     def _contains_jordan(
         self, jordan: JordanCurve, boundary: Optional[bool] = True
     ) -> bool:
-        piecewise = jordan.piecewise
+        piecewise = jordan.parametrize()
         vertices = map(piecewise, piecewise.knots)
         if not all(map(self.contains_point, vertices)):
             return False
@@ -370,7 +370,7 @@ class SimpleShape(DefinedShape):
         inters.evaluate()
         if inters.all_subsets[id(piecewise)] is not rbool.Empty():
             return True
-        knots = sorted(inters.all_knots[id(jordan.piecewise)])
+        knots = sorted(inters.all_knots[id(piecewise)])
         midknots = ((k0 + k1) / 2 for k0, k1 in zip(knots, knots[1:]))
         midpoints = map(piecewise, midknots)
         return all(map(self.contains_point, midpoints))

--- a/src/shapepy/geometry/base.py
+++ b/src/shapepy/geometry/base.py
@@ -37,28 +37,6 @@ class Future:
         raise NotImplementedError
 
 
-class IParametrizedCurve(ABC):
-    """
-    Class interface for parametrized curves
-    """
-
-    @property
-    @abstractmethod
-    def knots(self) -> Tuple[Real, ...]:
-        """
-        The length of the curve
-        If the curve is not bounded, returns infinity
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def __call__(self, node: Real, derivate: int = 0) -> Point2D:
-        raise NotImplementedError
-
-    def __or__(self, other: IParametrizedCurve) -> IParametrizedCurve:
-        return Future.concatenate((self, other))
-
-
 class IGeometricCurve(ABC):
     """
     Class interface for geometric curves
@@ -80,5 +58,36 @@ class IGeometricCurve(ABC):
         """
         raise NotImplementedError
 
-    def __and__(self, other: IGeometricCurve):
+    @abstractmethod
+    def parametrize(self) -> IParametrizedCurve:
+        """Gives a parametrized curve"""
+        raise NotImplementedError
+
+    def __or__(self, other: IGeometricCurve) -> IGeometricCurve:
+        return Future.concatenate((self, other))
+
+
+class IParametrizedCurve(IGeometricCurve):
+    """
+    Class interface for parametrized curves
+    """
+
+    @property
+    @abstractmethod
+    def knots(self) -> Tuple[Real, ...]:
+        """
+        The length of the curve
+        If the curve is not bounded, returns infinity
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def __call__(self, node: Real, derivate: int = 0) -> Point2D:
+        raise NotImplementedError
+
+    def __and__(self, other: IParametrizedCurve):
         return Future.intersect(self, other)
+
+    def parametrize(self) -> IParametrizedCurve:
+        """Gives a parametrized curve"""
+        return self

--- a/src/shapepy/geometry/box.py
+++ b/src/shapepy/geometry/box.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import Union
 
-from ..tools import To
+from ..tools import Is, To
 from .point import Point2D, cartesian
 
 
@@ -29,6 +29,11 @@ class Box:
     def __init__(self, lowpt: Point2D, toppt: Point2D):
         self.lowpt = To.point(lowpt)
         self.toppt = To.point(toppt)
+
+    def __eq__(self, other: Box) -> Box:
+        if not Is.instance(other, Box):
+            raise TypeError
+        return self.lowpt == other.lowpt and self.toppt == other.toppt
 
     def __str__(self) -> str:
         return f"Box with vertices {self.lowpt} and {self.toppt}"

--- a/src/shapepy/geometry/factory.py
+++ b/src/shapepy/geometry/factory.py
@@ -8,6 +8,7 @@ from ..tools import To
 from .jordancurve import JordanCurve
 from .point import Point2D
 from .segment import Segment, clean_segment
+from .unparam import USegment
 
 
 class FactoryJordan:
@@ -37,11 +38,11 @@ class FactoryJordan:
         vertices = list(map(To.point, vertices))
         nverts = len(vertices)
         vertices.append(vertices[0])
-        beziers = [0] * nverts
+        beziers = [None] * nverts
         for i in range(nverts):
             ctrlpoints = vertices[i : i + 2]
             new_bezier = Segment(ctrlpoints)
-            beziers[i] = new_bezier
+            beziers[i] = USegment(new_bezier)
         return JordanCurve(beziers)
 
     @staticmethod
@@ -74,4 +75,4 @@ class FactoryJordan:
         segments = (
             clean_segment(Segment(bezier.ctrlpoints)) for bezier in beziers
         )
-        return JordanCurve(segments)
+        return JordanCurve(map(USegment, segments))

--- a/src/shapepy/geometry/integral.py
+++ b/src/shapepy/geometry/integral.py
@@ -73,8 +73,8 @@ class IntegrateJordan:
         """
         assert Is.jordan(jordan)
         return sum(
-            IntegrateSegment.polynomial(segment, expx, expy)
-            for segment in jordan.segments
+            IntegrateSegment.polynomial(usegment.parametrize(), expx, expy)
+            for usegment in jordan.usegments
         )
 
     @staticmethod
@@ -89,11 +89,13 @@ class IntegrateJordan:
         """
         wind = 0
         if center in jordan.box():
-            for bezier in jordan.segments:
-                if center in bezier:
+            for usegment in jordan.usegments:
+                if center in usegment:
                     return 0.5 if jordan.area > 0 else -0.5
-        for bezier in jordan.segments:
-            wind += IntegrateSegment.winding_number(bezier, center, nnodes)
+        for usegment in jordan.usegments:
+            wind += IntegrateSegment.winding_number(
+                usegment.parametrize(), center, nnodes
+            )
         return round(wind)
 
 

--- a/src/shapepy/geometry/intersection.py
+++ b/src/shapepy/geometry/intersection.py
@@ -27,19 +27,9 @@ from ..scalar.nodes_sample import NodeSampleFactory
 from ..scalar.reals import Real
 from ..tools import Is, NotExpectedError
 from .base import IGeometricCurve, IParametrizedCurve
-from .jordancurve import JordanCurve
 from .piecewise import PiecewiseCurve
 from .point import cross, inner
 from .segment import Segment
-
-
-def parametrize(curve: IGeometricCurve) -> IParametrizedCurve:
-    """Parametrizes a curve, if it's not already parametrized"""
-    if Is.instance(curve, IParametrizedCurve):
-        return curve
-    if Is.instance(curve, JordanCurve):
-        return curve.piecewise
-    raise NotExpectedError
 
 
 def intersect(
@@ -158,7 +148,7 @@ class GeometricIntersectionCurves:
         self.__all_knots = {}
         self.__all_subsets = {}
         for curve in self.curves:
-            knots = parametrize(curve).knots
+            knots = curve.parametrize().knots
             self.__all_knots[id(curve)] = set(knots)
             self.__all_subsets[id(curve)] = Empty()
         for i, j in self.pairs:
@@ -182,7 +172,7 @@ class GeometricIntersectionCurves:
         if curvea.box() & curveb.box() is None:
             return Empty(), Empty()
         if id(curvea) == id(curveb):  # Check if curves are equal
-            curvea = parametrize(curvea)
+            curvea = curvea.parametrize()
             subset = Interval(curvea.knots[0], curvea.knots[-1])
             return subset, subset
         return curve_and_curve(curvea, curveb)
@@ -205,7 +195,7 @@ def curve_and_curve(
     curvea: IGeometricCurve, curveb: IGeometricCurve
 ) -> Tuple[SubSetR1, SubSetR1]:
     """Computes the intersection between two curves"""
-    return param_and_param(parametrize(curvea), parametrize(curveb))
+    return param_and_param(curvea.parametrize(), curveb.parametrize())
 
 
 def param_and_param(

--- a/src/shapepy/geometry/segment.py
+++ b/src/shapepy/geometry/segment.py
@@ -21,12 +21,12 @@ from ..analytic.tools import find_minimum
 from ..scalar.quadrature import AdaptativeIntegrator, IntegratorFactory
 from ..scalar.reals import Math, Real
 from ..tools import Is, To, vectorize
-from .base import IGeometricCurve, IParametrizedCurve
+from .base import IParametrizedCurve
 from .box import Box
 from .point import Point2D, cartesian
 
 
-class Segment(IGeometricCurve, IParametrizedCurve):
+class Segment(IParametrizedCurve):
     """
     Defines a planar curve in the plane,
     that contains a bezier curve inside it
@@ -40,11 +40,10 @@ class Segment(IGeometricCurve, IParametrizedCurve):
         self.__knots = (To.rational(0, 1), To.rational(1, 1))
 
     def __str__(self) -> str:
-        return f"Bezier Segment {tuple(self.ctrlpoints)}"
+        return f"BS[{len(self.ctrlpoints)-1}:{self(0)}->{self(1)}]"
 
     def __repr__(self) -> str:
-        msg = f"Segment (deg {self.degree})"
-        return msg
+        return str(self)
 
     def __eq__(self, other: Segment) -> bool:
         if not Is.segment(other):
@@ -195,11 +194,6 @@ def compute_length(segment: Segment) -> Real:
         return Math.sqrt(dpsquare(node))
 
     return adaptative.integrate(function, domain)
-
-
-def segment_self_intersect(segment: Segment) -> bool:
-    """Tells if the segment intersects itself"""
-    return len(segment.ctrlpoints) > 3
 
 
 def clean_segment(segment: Segment) -> Segment:

--- a/src/shapepy/geometry/unparam.py
+++ b/src/shapepy/geometry/unparam.py
@@ -1,0 +1,92 @@
+"""
+Defines the class USegment and UPiecewise, which is equivalent to
+"""
+
+from __future__ import annotations
+
+from copy import copy
+from typing import Union
+
+from ..scalar.reals import Real
+from ..tools import Is
+from .base import IGeometricCurve
+from .box import Box
+from .piecewise import PiecewiseCurve
+from .point import cross
+from .segment import Segment
+
+
+class USegment(IGeometricCurve):
+    """Equivalent to Segment, but ignores the parametrization"""
+
+    def __init__(self, segment: Segment):
+        self.__segment = segment
+
+    def __copy__(self) -> USegment:
+        return self.__deepcopy__(None)
+
+    def __deepcopy__(self, _) -> USegment:
+        """Returns a deep copy of the jordan curve"""
+        return self.__class__(copy(self.__segment))
+
+    def __contains__(self, other) -> bool:
+        return other in self.__segment
+
+    @property
+    def length(self) -> Real:
+        """
+        The length of the curve
+        If the curve is not bounded, returns infinity
+        """
+        return self.__segment.length
+
+    def box(self) -> Box:
+        """
+        Gives the box that encloses the curve
+        """
+        return self.__segment.box()
+
+    def parametrize(self) -> Segment:
+        """Gives a parametrized curve"""
+        return self.__segment
+
+    def __eq__(self, other: IGeometricCurve) -> bool:
+        if not Is.instance(other, IGeometricCurve):
+            raise TypeError
+        segi = self.parametrize()
+        segj = other.parametrize()
+        return segi(0) == segj(0) and segi(1) == segj(1)
+
+    def __or__(self, other: USegment) -> Union[USegment, PiecewiseCurve]:
+        if not Is.instance(other, USegment):
+            raise TypeError
+        segi = self.parametrize()
+        segj = other.parametrize()
+        if segi(1) != segj(0):
+            raise ValueError("Union is not continous")
+        if segi.npts == 2 and segj.npts == 2:
+            # They are linear
+            if abs(cross(segi(1, 1), segj(0, 1))) < 1e-9:
+                return USegment(
+                    Segment([segi.ctrlpoints[0], segj.ctrlpoints[1]])
+                )
+        return PiecewiseCurve([segi, segj])
+
+    def invert(self) -> USegment:
+        """Invert the current curve's orientation, doesn't create a copy
+
+        :return: The same curve
+        :rtype: USegment
+        """
+        self.__segment = self.__segment.invert()
+        return self
+
+
+def clean_usegment(usegment: USegment) -> USegment:
+    """Cleans the segment, simplifying the expression"""
+    return usegment
+
+
+def self_intersect(usegment: USegment) -> USegment:
+    """Checks if the USegment intersects itself"""
+    return len(usegment.parametrize().ctrlpoints) > 3

--- a/src/shapepy/plot/plot.py
+++ b/src/shapepy/plot/plot.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import Optional
 
 import matplotlib
-import numpy as np
 from matplotlib import pyplot
 
 from shapepy.bool2d.base import EmptyShape, WholeShape
@@ -26,6 +25,7 @@ def patch_segment(segment: Segment):
     """
     Creates the commands for matplotlib to plot the segment
     """
+    assert Is.instance(segment, Segment)
     vertices = []
     commands = []
     if segment.degree == 1:
@@ -44,9 +44,10 @@ def path_shape(connected: ConnectedShape) -> Path:
     vertices = []
     commands = []
     for jordan in connected.jordans:
-        vertices.append(jordan.segments[0].ctrlpoints[0])
+        segments = tuple(useg.parametrize() for useg in jordan.usegments)
+        vertices.append(segments[0].ctrlpoints[0])
         commands.append(Path.MOVETO)
-        for segment in jordan.segments:
+        for segment in segments:
             verts, comms = patch_segment(segment)
             vertices += verts
             commands += comms
@@ -60,9 +61,10 @@ def path_jordan(jordan: JordanCurve) -> Path:
     """
     Creates the commands for matplotlib to plot the jordan curve
     """
-    vertices = [jordan.segments[0].ctrlpoints[0]]
+    segments = tuple(useg.parametrize() for useg in jordan.usegments)
+    vertices = [segments[0].ctrlpoints[0]]
     commands = [Path.MOVETO]
-    for segment in jordan.segments:
+    for segment in segments:
         verts, comms = patch_segment(segment)
         vertices += verts
         commands += comms
@@ -174,5 +176,5 @@ class ShapePloter:
                     path, edgecolor=color, facecolor="none", lw=2
                 )
                 self.gca().add_patch(patch)
-                xvals, yvals = np.array(jordan.points(0), dtype="float64").T
+                xvals, yvals = zip(*jordan.vertices)
                 self.gca().scatter(xvals, yvals, color=color, marker=marker)

--- a/src/shapepy/tools.py
+++ b/src/shapepy/tools.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import types
 from functools import wraps
-from typing import Any
+from typing import Any, Iterable, Tuple
 
 import numpy as np
 
@@ -103,6 +103,28 @@ def vectorize(position: int = 0, dimension: int = 0):
         return wrapper
 
     return decorator
+
+
+def reverse(objs: Iterable[Any]) -> Iterable[Any]:
+    """Reverts the list/tuple"""
+    return tuple(objs)[::-1]
+
+
+def pairs(objs: Iterable[Any]) -> Iterable[Tuple[Any, Any]]:
+    """Gives pairs of the objects in sequence
+
+    Example
+    -------
+    >>> A = [0, 1, 2, 3]
+    >>> list(pairs(A))
+    [(0, 1), (1, 2), (2, 3), (3, 0)]
+    """
+    objs = tuple(objs)
+    if len(objs) <= 1:
+        raise ValueError(f"objs = {objs}")
+    if len(objs) > 1:
+        yield from zip(objs, objs[1:])
+        yield (objs[-1], objs[0])
 
 
 class NotExpectedError(Exception):

--- a/tests/bool2d/test_contains.py
+++ b/tests/bool2d/test_contains.py
@@ -305,30 +305,6 @@ class TestObjectsInSimple:
             "TestObjectsInSimple::test_whole",
         ]
     )
-    def test_keep_ids(self):
-        np.random.seed(0)
-
-        square = Primitive.square(side=4)
-        jordan = square.jordans[0]
-        good_ids = tuple(id(vertex) for vertex in jordan.vertices)
-
-        for _ in range(100):  # number of tests
-            point = np.random.uniform(-4, 4, 2)
-            point in square
-            jordan = square.jordans[0]
-            test_ids = tuple(id(vertex) for vertex in jordan.vertices)
-            assert len(test_ids) == len(good_ids)
-            assert test_ids == good_ids
-
-    @pytest.mark.order(23)
-    @pytest.mark.dependency(
-        depends=[
-            "TestObjectsInSimple::test_begin",
-            "TestObjectsInSimple::test_empty",
-            "TestObjectsInSimple::test_whole",
-            "TestObjectsInSimple::test_keep_ids",
-        ]
-    )
     def test_keep_type(self):
         square = Primitive.square(side=4)
         good_types = []
@@ -351,7 +327,6 @@ class TestObjectsInSimple:
             "TestObjectsInSimple::test_begin",
             "TestObjectsInSimple::test_empty",
             "TestObjectsInSimple::test_whole",
-            "TestObjectsInSimple::test_keep_ids",
             "TestObjectsInSimple::test_keep_type",
         ]
     )
@@ -385,7 +360,6 @@ class TestObjectsInSimple:
             "TestObjectsInSimple::test_begin",
             "TestObjectsInSimple::test_empty",
             "TestObjectsInSimple::test_whole",
-            "TestObjectsInSimple::test_keep_ids",
             "TestObjectsInSimple::test_keep_type",
             "TestObjectsInSimple::test_point",
         ]
@@ -420,7 +394,6 @@ class TestObjectsInSimple:
             "TestObjectsInSimple::test_begin",
             "TestObjectsInSimple::test_empty",
             "TestObjectsInSimple::test_whole",
-            "TestObjectsInSimple::test_keep_ids",
             "TestObjectsInSimple::test_keep_type",
             "TestObjectsInSimple::test_point",
             "TestObjectsInSimple::test_jordan",

--- a/tests/geometry/test_jordan_curve.py
+++ b/tests/geometry/test_jordan_curve.py
@@ -99,17 +99,19 @@ class TestQuadraticJordan:
         curvea = pynurbs.Curve(knotvector)
         curvea.ctrlpoints = [To.point(pt) for pt in pointsa]
         jordana = FactoryJordan.spline_curve(curvea)
+        piecea = jordana.parametrize()
 
         pointsb = [(3, -2), (-1, 0), (3, 2), (3, 0), (3, -2)]
         curveb = pynurbs.Curve(knotvector)
         curveb.ctrlpoints = [To.point(pt) for pt in pointsb]
         jordanb = FactoryJordan.spline_curve(curveb)
+        pieceb = jordanb.parametrize()
 
-        test = jordana & jordanb
-        assert equal_sets(test.all_knots[id(jordana)], {0, 0.25, 0.75, 1, 2})
-        assert equal_sets(test.all_knots[id(jordanb)], {0, 0.25, 0.75, 1, 2})
-        assert equal_rbool_sets(test.all_subsets[id(jordana)], {0.25, 0.75})
-        assert equal_rbool_sets(test.all_subsets[id(jordanb)], {0.25, 0.75})
+        test = piecea & pieceb
+        assert equal_sets(test.all_knots[id(piecea)], {0, 0.25, 0.75, 1, 2})
+        assert equal_sets(test.all_knots[id(pieceb)], {0, 0.25, 0.75, 1, 2})
+        assert equal_rbool_sets(test.all_subsets[id(piecea)], {0.25, 0.75})
+        assert equal_rbool_sets(test.all_subsets[id(pieceb)], {0.25, 0.75})
 
     @pytest.mark.order(16)
     @pytest.mark.timeout(10)
@@ -129,18 +131,20 @@ class TestQuadraticJordan:
         curvea = pynurbs.Curve(knotvector)
         curvea.ctrlpoints = [To.point(pt) for pt in pointsa]
         jordana = FactoryJordan.spline_curve(curvea)
+        piecea = jordana.parametrize()
 
         pointsb = [(3, -2), (-1, 0), (3, 2), (3, 0), (3, -2)]
         pointsb = np.array(pointsb, dtype="float64")
         curveb = pynurbs.Curve(knotvector)
         curveb.ctrlpoints = [To.point(pt) for pt in pointsb]
         jordanb = FactoryJordan.spline_curve(curveb)
+        pieceb = jordanb.parametrize()
 
-        test = jordana & jordanb
-        assert equal_sets(test.all_knots[id(jordana)], {0, 0.25, 0.75, 1, 2})
-        assert equal_sets(test.all_knots[id(jordanb)], {0, 0.25, 0.75, 1, 2})
-        assert equal_rbool_sets(test.all_subsets[id(jordana)], {0.25, 0.75})
-        assert equal_rbool_sets(test.all_subsets[id(jordanb)], {0.25, 0.75})
+        test = piecea & pieceb
+        assert equal_sets(test.all_knots[id(piecea)], {0, 0.25, 0.75, 1, 2})
+        assert equal_sets(test.all_knots[id(pieceb)], {0, 0.25, 0.75, 1, 2})
+        assert equal_rbool_sets(test.all_subsets[id(piecea)], {0.25, 0.75})
+        assert equal_rbool_sets(test.all_subsets[id(pieceb)], {0.25, 0.75})
 
     @pytest.mark.order(16)
     @pytest.mark.timeout(10)

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -63,27 +63,6 @@ class TestJordanPolygon:
             "TestJordanPolygon::test_error_creation",
         ]
     )
-    def test_id_points(self):
-        points = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        jordan = FactoryJordan.polygon(points)
-        segments = jordan.segments
-        for i, segi in enumerate(segments):
-            segj = segments[(i + 1) % len(segments)]
-            last_point = segi.ctrlpoints[-1]
-            first_point = segj.ctrlpoints[0]
-            assert last_point == first_point
-            assert id(last_point) == id(first_point)
-
-    @pytest.mark.order(15)
-    @pytest.mark.timeout(20)
-    @pytest.mark.dependency(
-        depends=[
-            "TestJordanPolygon::test_begin",
-            "TestJordanPolygon::test_creation",
-            "TestJordanPolygon::test_error_creation",
-            "TestJordanPolygon::test_id_points",
-        ]
-    )
     def test_equal_curves(self):
         postri0 = FactoryJordan.polygon([(0, 0), (1, 0), (0, 1)])
         postri1 = FactoryJordan.polygon([(1, 0), (0, 1), (0, 0)])
@@ -108,7 +87,6 @@ class TestJordanPolygon:
             "TestJordanPolygon::test_begin",
             "TestJordanPolygon::test_creation",
             "TestJordanPolygon::test_error_creation",
-            "TestJordanPolygon::test_id_points",
             "TestJordanPolygon::test_equal_curves",
         ]
     )
@@ -137,7 +115,6 @@ class TestJordanPolygon:
             "TestJordanPolygon::test_begin",
             "TestJordanPolygon::test_creation",
             "TestJordanPolygon::test_error_creation",
-            "TestJordanPolygon::test_id_points",
             "TestJordanPolygon::test_equal_curves",
         ]
     )
@@ -162,7 +139,6 @@ class TestJordanPolygon:
             "TestJordanPolygon::test_begin",
             "TestJordanPolygon::test_creation",
             "TestJordanPolygon::test_error_creation",
-            "TestJordanPolygon::test_id_points",
             "TestJordanPolygon::test_equal_curves",
             "TestJordanPolygon::test_nonequal_curves",
             "TestJordanPolygon::test_invert_curves",
@@ -173,51 +149,58 @@ class TestJordanPolygon:
         square0 = FactoryJordan.polygon(vertices0)
         vertices1 = [(-1, 0), (1, 2), (3, 0), (1, -2)]
         square1 = FactoryJordan.polygon(vertices1)
+        param0 = square0.parametrize()
+        param1 = square1.parametrize()
 
-        inters = square0 & square0
-        assert inters.all_subsets[id(square0)] == [0, 4]
-        assert inters.all_knots[id(square0)] == {0, 1, 2, 3, 4}
-        inters = square1 & square1
-        assert inters.all_subsets[id(square1)] == [0, 4]
-        assert inters.all_knots[id(square1)] == {0, 1, 2, 3, 4}
+        inters = param0 & param0
+        assert inters.all_subsets[id(param0)] == [0, 4]
+        assert inters.all_knots[id(param0)] == {0, 1, 2, 3, 4}
+        inters = param1 & param1
+        assert inters.all_subsets[id(param1)] == [0, 4]
+        assert inters.all_knots[id(param1)] == {0, 1, 2, 3, 4}
 
-        inters = square0 & square1
-        assert inters.all_subsets[id(square0)] == {0.5, 3.5}
-        assert inters.all_knots[id(square0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
-        assert inters.all_subsets[id(square1)] == {0.5, 3.5}
-        assert inters.all_knots[id(square1)] == {0, 0.5, 1, 2, 3, 3.5, 4}
+        inters = param0 & param1
+        print(param0)
+        print(param1)
+        print(inters)
+        assert inters.all_subsets[id(param0)] == {0.5, 3.5}
+        assert inters.all_knots[id(param0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
+        assert inters.all_subsets[id(param1)] == {0.5, 3.5}
+        assert inters.all_knots[id(param1)] == {0, 0.5, 1, 2, 3, 3.5, 4}
 
         vertices1 = [(-1, 0), (1, -2), (3, 0), (1, 2)]
         square1 = FactoryJordan.polygon(vertices1)
+        param1 = square1.parametrize()
 
-        inters = square0 & square0
-        assert inters.all_subsets[id(square0)] == [0, 4]
-        assert inters.all_knots[id(square0)] == {0, 1, 2, 3, 4}
-        inters = square1 & square1
-        assert inters.all_subsets[id(square1)] == [0, 4]
-        assert inters.all_knots[id(square1)] == {0, 1, 2, 3, 4}
+        inters = param0 & param0
+        assert inters.all_subsets[id(param0)] == [0, 4]
+        assert inters.all_knots[id(param0)] == {0, 1, 2, 3, 4}
+        inters = param1 & param1
+        assert inters.all_subsets[id(param1)] == [0, 4]
+        assert inters.all_knots[id(param1)] == {0, 1, 2, 3, 4}
 
-        inters = square0 & square1
-        assert inters.all_subsets[id(square0)] == {0.5, 3.5}
-        assert inters.all_knots[id(square0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
-        assert inters.all_subsets[id(square1)] == {0.5, 3.5}
-        assert inters.all_knots[id(square1)] == {0, 0.5, 1, 2, 3, 3.5, 4}
+        inters = param0 & param1
+        assert inters.all_subsets[id(param0)] == {0.5, 3.5}
+        assert inters.all_knots[id(param0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
+        assert inters.all_subsets[id(param1)] == {0.5, 3.5}
+        assert inters.all_knots[id(param1)] == {0, 0.5, 1, 2, 3, 3.5, 4}
 
         vertices1 = [(1, -2), (3, 0), (1, 2), (-1, 0)]
         square1 = FactoryJordan.polygon(vertices1)
+        param1 = square1.parametrize()
 
-        inters = square0 & square0
-        assert inters.all_subsets[id(square0)] == [0, 4]
-        assert inters.all_knots[id(square0)] == {0, 1, 2, 3, 4}
-        inters = square1 & square1
-        assert inters.all_subsets[id(square1)] == [0, 4]
-        assert inters.all_knots[id(square1)] == {0, 1, 2, 3, 4}
+        inters = param0 & param0
+        assert inters.all_subsets[id(param0)] == [0, 4]
+        assert inters.all_knots[id(param0)] == {0, 1, 2, 3, 4}
+        inters = param1 & param1
+        assert inters.all_subsets[id(param1)] == [0, 4]
+        assert inters.all_knots[id(param1)] == {0, 1, 2, 3, 4}
 
-        inters = square0 & square1
-        assert inters.all_subsets[id(square0)] == {0.5, 3.5}
-        assert inters.all_knots[id(square0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
-        assert inters.all_subsets[id(square1)] == {2.5, 3.5}
-        assert inters.all_knots[id(square1)] == {0, 1, 2, 2.5, 3, 3.5, 4}
+        inters = param0 & param1
+        assert inters.all_subsets[id(param0)] == {0.5, 3.5}
+        assert inters.all_knots[id(param0)] == {0, 0.5, 1, 2, 3, 3.5, 4}
+        assert inters.all_subsets[id(param1)] == {2.5, 3.5}
+        assert inters.all_knots[id(param1)] == {0, 1, 2, 2.5, 3, 3.5, 4}
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)
@@ -226,7 +209,6 @@ class TestJordanPolygon:
             "TestJordanPolygon::test_begin",
             "TestJordanPolygon::test_creation",
             "TestJordanPolygon::test_error_creation",
-            "TestJordanPolygon::test_id_points",
             "TestJordanPolygon::test_equal_curves",
             "TestJordanPolygon::test_nonequal_curves",
             "TestJordanPolygon::test_invert_curves",
@@ -323,56 +305,6 @@ class TestTransformationPolygon:
         assert test_square != inve_square
 
     @pytest.mark.order(15)
-    @pytest.mark.timeout(20)
-    @pytest.mark.dependency(
-        depends=[
-            "TestTransformationPolygon::test_begin",
-            "TestTransformationPolygon::test_move",
-            "TestTransformationPolygon::test_scale",
-            "TestTransformationPolygon::test_rotate",
-            "TestTransformationPolygon::test_invert",
-        ]
-    )
-    def test_split(self):
-        square_pts = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-        good_square = FactoryJordan.polygon(square_pts)
-        test_square = FactoryJordan.polygon(square_pts)
-        test_square.piecewise.split([0.5, 2.5, 3.5])
-        assert test_square == good_square
-
-    @pytest.mark.order(15)
-    @pytest.mark.timeout(20)
-    @pytest.mark.dependency(
-        depends=[
-            "TestTransformationPolygon::test_begin",
-            "TestTransformationPolygon::test_move",
-            "TestTransformationPolygon::test_scale",
-            "TestTransformationPolygon::test_rotate",
-            "TestTransformationPolygon::test_invert",
-            "TestTransformationPolygon::test_split",
-        ]
-    )
-    def test_keep_ids(self):
-        square_vertices = [(0, 0), (1, 0), (1, 1), (0, 1)]
-        square = FactoryJordan.polygon(square_vertices)
-        good_ids = tuple(id(vertex) for vertex in square.vertices)
-
-        square.move((2, 3))
-        test_ids = tuple(id(vertex) for vertex in square.vertices)
-        assert len(test_ids) == len(good_ids)
-        assert test_ids == good_ids
-
-        square.rotate(90, degrees=True)
-        test_ids = tuple(id(vertex) for vertex in square.vertices)
-        assert len(test_ids) == len(good_ids)
-        assert test_ids == good_ids
-
-        square.scale(5, 4)
-        test_ids = tuple(id(vertex) for vertex in square.vertices)
-        assert len(test_ids) == len(good_ids)
-        assert test_ids == good_ids
-
-    @pytest.mark.order(15)
     @pytest.mark.timeout(1)
     @pytest.mark.dependency(
         depends=[
@@ -380,8 +312,6 @@ class TestTransformationPolygon:
             "TestTransformationPolygon::test_rotate",
             "TestTransformationPolygon::test_scale",
             "TestTransformationPolygon::test_invert",
-            "TestTransformationPolygon::test_split",
-            "TestTransformationPolygon::test_keep_ids",
         ]
     )
     def test_end(self):
@@ -481,6 +411,8 @@ class TestIntegrateJordan:
             jordan_curve = FactoryJordan.polygon(ctrlpoints)
             assert abs(jordan_curve.length - lenght) < 1e-15
             assert abs(jordan_curve.area - area) < 1e-15
+
+            assert (jordan_curve.length - lenght) < 1e-9
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)


### PR DESCRIPTION
This PR adds a new class `USegment` which is equivalent to the `Segment` but doesn't have parameters.

The main motivation is to allow compare two `Segment` with different parameters.
Example, suppose:

$$p(t) = (1 - t, 2 + 3 t)$$

$$q(t) = (1 - t^3, 2 + 3t^3)$$

We see that $p(t) != q(t)$, but in fact both leads to the same set of points.

With the addition of this class, comparing two `JordanCurve` instances becomes easier