### PR TITLE
Feat: add transformation function to most 2D classes

### DIFF
--- a/src/shapepy/__init__.py
+++ b/src/shapepy/__init__.py
@@ -10,6 +10,7 @@ import importlib
 from shapepy.bool2d.base import EmptyShape, WholeShape
 from shapepy.bool2d.primitive import Primitive
 from shapepy.bool2d.shape import ConnectedShape, DisjointShape, SimpleShape
+from shapepy.common import move, rotate, scale
 from shapepy.geometry.integral import IntegrateJordan
 from shapepy.geometry.jordancurve import JordanCurve
 from shapepy.geometry.point import Point2D

--- a/src/shapepy/bool2d/base.py
+++ b/src/shapepy/bool2d/base.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from copy import copy
-from typing import Iterable
+from typing import Iterable, Tuple, Union
+
+from ..geometry.point import Point2D
+from ..scalar.angle import Angle
+from ..scalar.reals import Real
 
 
 class SubSetR2:
@@ -64,6 +68,75 @@ class SubSetR2:
     def __repr__(self) -> str:  # pragma: no cover
         return str(self)
 
+    @abstractmethod
+    def move(self, vector: Point2D) -> SubSetR2:
+        """
+        Moves/translate entire shape by an amount
+
+        Parameters
+        ----------
+
+        point : Point2D
+            The amount to move
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.move(1, 2)
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> SubSetR2:
+        """
+        Scales entire subset by an amount
+
+        Parameters
+        ----------
+
+        amount : Real | Tuple[Real, Real]
+            The amount to scale in horizontal and vertical direction
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.scale((2, 3))
+
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def rotate(self, angle: Angle) -> SubSetR2:
+        """
+        Rotates entire shape around the origin by an amount
+
+        Parameters
+        ----------
+
+        angle : Angle
+            The amount to rotate around origin
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.rotate(Angle.degrees(90))
+
+        """
+        raise NotImplementedError
+
 
 class EmptyShape(SubSetR2):
     """EmptyShape is a singleton class to represent an empty shape
@@ -114,6 +187,15 @@ class EmptyShape(SubSetR2):
     def __bool__(self) -> bool:
         return False
 
+    def move(self, _):
+        return self
+
+    def scale(self, _):
+        return self
+
+    def rotate(self, _):
+        return self
+
 
 class WholeShape(SubSetR2):
     """WholeShape is a singleton class to represent all plane
@@ -163,6 +245,15 @@ class WholeShape(SubSetR2):
 
     def __bool__(self) -> bool:
         return True
+
+    def move(self, _):
+        return self
+
+    def scale(self, _):
+        return self
+
+    def rotate(self, _):
+        return self
 
 
 class Future:

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -20,6 +20,7 @@ from ..geometry.box import Box
 from ..geometry.integral import IntegrateJordan
 from ..geometry.jordancurve import JordanCurve
 from ..geometry.point import Point2D
+from ..scalar.angle import Angle
 from ..scalar.reals import Real
 from ..tools import Is, To
 from .base import EmptyShape, SubSetR2
@@ -71,83 +72,6 @@ class DefinedShape(SubSetR2):
             return self.contains_jordan(other)
         point = To.point(other)
         return self.contains_point(point)
-
-    def move(self, point: Point2D) -> SubSetR2:
-        """
-        Moves/translate entire shape by an amount
-
-        Parameters
-        ----------
-
-        point : Point2D
-            The amount to move
-
-        :return: The same instance
-        :rtype: SubSetR2
-
-        Example use
-        -----------
-        >>> from shapepy import Primitive
-        >>> circle = Primitive.circle()
-        >>> circle.move(1, 2)
-
-        """
-        point = To.point(point)
-        for jordan in self.jordans:
-            jordan.move(point)
-        return self
-
-    def scale(self, xscale: float, yscale: float) -> SubSetR2:
-        """
-        Scales entire shape by an amount
-
-        Parameters
-        ----------
-
-        xscale : float
-            The amount to scale in horizontal direction
-        yscale : float
-            The amount to scale in vertical direction
-
-        :return: The same instance
-        :rtype: SubSetR2
-
-        Example use
-        -----------
-        >>> from shapepy import Primitive
-        >>> circle = Primitive.circle()
-        >>> circle.scale(2, 3)
-
-        """
-        for jordan in self.jordans:
-            jordan.scale(xscale, yscale)
-        return self
-
-    def rotate(self, angle: float, degrees: bool = False) -> SubSetR2:
-        """
-        Rotates entire shape around the origin by an amount
-
-        Parameters
-        ----------
-
-        angle : float
-            The amount to rotate around origin
-        degrees : bool, default = False
-            Flag to indicate if ``angle`` is in radians or degrees
-
-        :return: The same instance
-        :rtype: SubSetR2
-
-        Example use
-        -----------
-        >>> from shapepy import Primitive
-        >>> circle = Primitive.circle()
-        >>> circle.rotate(angle = 90, degrees = True)
-
-        """
-        for jordan in self.jordans:
-            jordan.rotate(angle, degrees)
-        return self
 
     def contains_point(
         self, point: Point2D, boundary: Optional[bool] = True
@@ -419,6 +343,18 @@ class SimpleShape(DefinedShape):
         # may happens error here
         return True
 
+    def move(self, vector: Point2D) -> JordanCurve:
+        self.__jordancurve = self.__jordancurve.move(vector)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> JordanCurve:
+        self.__jordancurve = self.__jordancurve.scale(amount)
+        return self
+
+    def rotate(self, angle: Angle) -> JordanCurve:
+        self.__jordancurve = self.__jordancurve.rotate(angle)
+        return self
+
 
 class ConnectedShape(DefinedShape):
     """
@@ -528,6 +464,23 @@ class ConnectedShape(DefinedShape):
             if not subshape.contains_shape(other):
                 return False
         return True
+
+    def move(self, vector: Point2D) -> JordanCurve:
+        vector = To.point(vector)
+        for subshape in self.subshapes:
+            subshape.move(vector)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> JordanCurve:
+        for subshape in self.subshapes:
+            subshape.scale(amount)
+        return self
+
+    def rotate(self, angle: Angle) -> JordanCurve:
+        angle = To.angle(angle)
+        for subshape in self.subshapes:
+            subshape.rotate(angle)
+        return self
 
 
 class DisjointShape(DefinedShape):
@@ -680,6 +633,23 @@ class DisjointShape(DefinedShape):
         values = sorted(zip(areas, lenghts, values), key=algori, reverse=True)
         values = tuple(val[2] for val in values)
         self.__subshapes = tuple(values)
+
+    def move(self, vector: Point2D) -> JordanCurve:
+        vector = To.point(vector)
+        for subshape in self.subshapes:
+            subshape.move(vector)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> JordanCurve:
+        for subshape in self.subshapes:
+            subshape.scale(amount)
+        return self
+
+    def rotate(self, angle: Angle) -> JordanCurve:
+        angle = To.angle(angle)
+        for subshape in self.subshapes:
+            subshape.rotate(angle)
+        return self
 
 
 def divide_connecteds(

--- a/src/shapepy/common.py
+++ b/src/shapepy/common.py
@@ -1,0 +1,82 @@
+"""Defines methods that are common for the entire package"""
+
+from copy import deepcopy
+from typing import Any, Tuple
+
+from .scalar.angle import Angle
+from .scalar.reals import Real
+from .tools import To
+
+
+def move(obj: Any, vector: Tuple[Real, Real]) -> Any:
+    """
+    Moves/translate 2D object in the plane
+
+    Parameters
+    ----------
+
+    point : Point2D
+        The amount to move
+
+    :return: The same instance
+    :rtype: SubSetR2
+
+    Example use
+    -----------
+    >>> from shapepy import Primitive
+    >>> circle = Primitive.circle()
+    >>> circle.move(1, 2)
+
+    """
+    vector = To.point(vector)
+    if hasattr(obj, "move"):
+        return deepcopy(obj).move(vector)
+    raise ValueError(f"Cannot move the object of type {type(obj)}")
+
+
+def scale(obj: Any, amount: Tuple[Real, Tuple[Real, Real]]) -> Any:
+    """
+    Moves/translate 2D object in the plane
+
+    Parameters
+    ----------
+
+    point : Point2D
+        The amount to move
+
+    :return: The same instance
+    :rtype: SubSetR2
+
+    Example use
+    -----------
+    >>> from shapepy import Primitive
+    >>> circle = Primitive.circle()
+    >>> circle.move(1, 2)
+
+    """
+    if hasattr(obj, "scale"):
+        return deepcopy(obj).scale(amount)
+    raise ValueError(f"Cannot scale the object of type {type(obj)}")
+
+
+def rotate(obj: Any, angle: Angle) -> Any:
+    """
+    Moves/translate 2D object in the plane
+
+    Parameters
+    ----------
+
+    point : Point2D
+        The amount to move
+
+    :return: The same instance
+    :rtype: SubSetR2
+
+    Example use
+    -----------
+    >>> from shapepy import Primitive
+    >>> circle = Primitive.circle()
+    >>> circle.move(1, 2)
+
+    """
+    return deepcopy(obj).rotate(angle)

--- a/src/shapepy/geometry/base.py
+++ b/src/shapepy/geometry/base.py
@@ -5,8 +5,9 @@ Defines the base class for Geometric curves
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Iterable, Tuple
+from typing import Iterable, Tuple, Union
 
+from ..scalar.angle import Angle
 from ..scalar.reals import Real
 from .box import Box
 from .point import Point2D
@@ -65,6 +66,73 @@ class IGeometricCurve(ABC):
 
     def __or__(self, other: IGeometricCurve) -> IGeometricCurve:
         return Future.concatenate((self, other))
+
+    @abstractmethod
+    def move(self, vector: Point2D) -> IGeometricCurve:
+        """
+        Moves/translate entire shape by an amount
+
+        Parameters
+        ----------
+
+        point : Point2D
+            The amount to move
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.move(1, 2)
+
+        """
+        raise NotImplementedError
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> IGeometricCurve:
+        """
+        Scales entire subset by an amount
+
+        Parameters
+        ----------
+
+        amount : Real | Tuple[Real, Real]
+            The amount to scale in horizontal and vertical direction
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.scale(2, 3)
+
+        """
+        raise NotImplementedError
+
+    def rotate(self, angle: Angle) -> IGeometricCurve:
+        """
+        Rotates entire shape around the origin by an amount
+
+        Parameters
+        ----------
+
+        angle : Angle
+            The amount to rotate around origin
+
+        :return: The same instance
+        :rtype: SubSetR2
+
+        Example use
+        -----------
+        >>> from shapepy import Primitive
+        >>> circle = Primitive.circle()
+        >>> circle.rotate(Angle.degrees(90))
+
+        """
+        raise NotImplementedError
 
 
 class IParametrizedCurve(IGeometricCurve):

--- a/src/shapepy/geometry/jordancurve.py
+++ b/src/shapepy/geometry/jordancurve.py
@@ -7,11 +7,11 @@ from __future__ import annotations
 
 from collections import deque
 from copy import copy
-from typing import Deque, Iterable, Tuple
+from typing import Deque, Iterable, Tuple, Union
 
 from ..scalar.angle import Angle
 from ..scalar.reals import Real
-from ..tools import Is, To, pairs, reverse
+from ..tools import Is, pairs, reverse
 from .base import IGeometricCurve
 from .box import Box
 from .piecewise import PiecewiseCurve
@@ -36,88 +36,16 @@ class JordanCurve(IGeometricCurve):
         """Returns a deep copy of the jordan curve"""
         return self.__class__(map(copy, self.usegments))
 
-    def move(self, point: Point2D) -> JordanCurve:
-        """Translate the entire curve by ``point``
-
-        :param point: The translation amount
-        :type point: Point2D
-        :return: The same curve
-        :rtype: JordanCurve
-
-        Example use
-        -----------
-
-        >>> from shapepy import JordanCurve
-        >>> vertices = [(0, 0), (4, 0), (0, 3)]
-        >>> jordan = FactoryJordan.polygon(vertices)
-        >>> jordan.move((2, 3))
-        Jordan Curve of degree 1 and vertices
-        ((2, 3), (6, 3), (2, 6))
-
-        """
-        point = To.point(point)
-        for ctrlpt in get_ctrlpoints(self):
-            ctrlpt.move(point)
+    def move(self, vector: Point2D) -> JordanCurve:
+        self.__piecewise = self.piecewise.move(vector)
         return self
 
-    def scale(self, xscale: float, yscale: float) -> JordanCurve:
-        """Scale the entire curve in horizontal and vertical direction
-
-        :param xscale: The scale in horizontal direction
-        :type xscale: float
-        :param yscale: The scale in vertical direction
-        :type yscale: float
-        :return: The same curve
-        :rtype: JordanCurve
-
-        Example use
-        -----------
-
-        >>> from shapepy import JordanCurve
-        >>> vertices = [(0, 0), (4, 0), (0, 3)]
-        >>> jordan = FactoryJordan.polygon(vertices)
-        >>> jordan.scale(2, 3)
-        Jordan Curve of degree 1 and vertices
-        ((0, 0), (8, 0), (0, 9))
-        >>> jordan.scale(1/2, 1/3)
-        Jordan Curve of degree 1 and vertices
-        ((0.0, 0.0), (4.0, 0.0), (0.0, 3.0))
-
-        """
-        xscale = To.finite(xscale)
-        yscale = To.finite(yscale)
-        for ctrlpt in get_ctrlpoints(self):
-            ctrlpt.scale(xscale, yscale)
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> JordanCurve:
+        self.__piecewise = self.piecewise.scale(amount)
         return self
 
-    def rotate(self, angle: float, degrees: bool = False) -> JordanCurve:
-        """Rotate the entire curve around the origin
-
-        :param angle: The amount to rotate
-        :type angle: float
-        :param degrees: If the angle is in radians (``degrees=False``)
-        :type degrees: bool(, optional)
-        :return: The same curve
-        :rtype: JordanCurve
-
-        Example use
-        -----------
-
-        >>> import math
-        >>> from shapepy import JordanCurve
-        >>> vertices = [(0, 0), (4, 0), (0, 3)]
-        >>> jordan = FactoryJordan.polygon(vertices)
-        >>> jordan.rotate(math.pi)
-        Jordan Curve of degree 1 and vertices
-        ((-0.0, 0.0), (-4.0, 4.899e-16), (-3.674e-16, -3.0))
-        >>> jordan.rotate(180, degrees=True)
-        Jordan Curve of degree 1 and vertices
-        ((0.0, -0.0), (4.0, -9.797e-16), (7.348e-16, 3.0))
-
-        """
-        angle = To.angle(angle) if not degrees else Angle.degrees(angle)
-        for ctrlpt in get_ctrlpoints(self):
-            ctrlpt.rotate(angle)
+    def rotate(self, angle: Angle) -> JordanCurve:
+        self.__piecewise = self.piecewise.rotate(angle)
         return self
 
     def box(self) -> Box:

--- a/src/shapepy/geometry/piecewise.py
+++ b/src/shapepy/geometry/piecewise.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Iterable, Tuple, Union
 
+from ..scalar.angle import Angle
 from ..scalar.reals import Real
 from ..tools import Is, To
 from .base import IParametrizedCurve
@@ -154,6 +155,20 @@ class PiecewiseCurve(IParametrizedCurve):
     def __contains__(self, point: Point2D) -> bool:
         """Tells if the point is on the boundary"""
         return any(point in bezier for bezier in self)
+
+    def move(self, vector: Point2D) -> PiecewiseCurve:
+        vector = To.point(vector)
+        self.__segments = tuple(seg.move(vector) for seg in self)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> Segment:
+        self.__segments = tuple(seg.scale(amount) for seg in self)
+        return self
+
+    def rotate(self, angle: Angle) -> Segment:
+        angle = To.angle(angle)
+        self.__segments = tuple(seg.rotate(angle) for seg in self)
+        return self
 
 
 def is_piecewise(obj: object) -> bool:

--- a/src/shapepy/geometry/point.py
+++ b/src/shapepy/geometry/point.py
@@ -6,6 +6,8 @@ They are used to encapsulate some commands
 
 from __future__ import annotations
 
+from typing import Tuple, Union
+
 from ..scalar.angle import Angle
 from ..scalar.reals import Math, Real
 from ..tools import Is, To
@@ -166,7 +168,7 @@ class Point2D:
         self.__ycoord += vector[1]
         return self
 
-    def scale(self, xscale: float, yscale: float) -> Point2D:
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> Point2D:
         """
         Scales the point by the given factors
 
@@ -182,6 +184,7 @@ class Point2D:
         Point2D
             The scaled point
         """
+        xscale, yscale = (amount, amount) if Is.real(amount) else amount
         self.__xcoord *= xscale
         self.__ycoord *= yscale
         return self

--- a/src/shapepy/geometry/segment.py
+++ b/src/shapepy/geometry/segment.py
@@ -13,11 +13,12 @@ File that defines the classes
 from __future__ import annotations
 
 from copy import copy
-from typing import Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple, Union
 
 from ..analytic.base import IAnalytic
 from ..analytic.bezier import Bezier
 from ..analytic.tools import find_minimum
+from ..scalar.angle import Angle
 from ..scalar.quadrature import AdaptativeIntegrator, IntegratorFactory
 from ..scalar.reals import Math, Real
 from ..tools import Is, To, vectorize
@@ -174,6 +175,20 @@ class Segment(IParametrizedCurve):
             bezier = Bezier(self.__planar).shift(-ka).scale(1 / (kb - ka))
             segments.append(Segment(bezier))
         return tuple(segments)
+
+    def move(self, vector: Point2D) -> Segment:
+        vector = To.point(vector)
+        self.ctrlpoints = (copy(pt).move(vector) for pt in self.ctrlpoints)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> Segment:
+        self.ctrlpoints = (copy(pt).scale(amount) for pt in self.ctrlpoints)
+        return self
+
+    def rotate(self, angle: Angle) -> Segment:
+        angle = To.angle(angle)
+        self.ctrlpoints = (copy(pt).rotate(angle) for pt in self.ctrlpoints)
+        return self
 
 
 def compute_length(segment: Segment) -> Real:

--- a/src/shapepy/geometry/unparam.py
+++ b/src/shapepy/geometry/unparam.py
@@ -5,14 +5,15 @@ Defines the class USegment and UPiecewise, which is equivalent to
 from __future__ import annotations
 
 from copy import copy
-from typing import Union
+from typing import Tuple, Union
 
+from ..scalar.angle import Angle
 from ..scalar.reals import Real
 from ..tools import Is
 from .base import IGeometricCurve
 from .box import Box
 from .piecewise import PiecewiseCurve
-from .point import cross
+from .point import Point2D, cross
 from .segment import Segment
 
 
@@ -79,6 +80,18 @@ class USegment(IGeometricCurve):
         :rtype: USegment
         """
         self.__segment = self.__segment.invert()
+        return self
+
+    def move(self, vector: Point2D) -> Segment:
+        self.__segment.move(vector)
+        return self
+
+    def scale(self, amount: Union[Real, Tuple[Real, Real]]) -> Segment:
+        self.__segment.scale(amount)
+        return self
+
+    def rotate(self, angle: Angle) -> Segment:
+        self.__segment.rotate(angle)
         return self
 
 

--- a/src/shapepy/scalar/__init__.py
+++ b/src/shapepy/scalar/__init__.py
@@ -1,0 +1,8 @@
+"""Defines the scalar submodule for shapepy package
+
+It contains the functions of conversion between the standard numbers,
+defines the class Angle to handle conversions between radians and degrees,
+defines the methods of numerical integration (quadrature)"""
+
+from .angle import Angle
+from .reals import Math, Rational, Real

--- a/src/shapepy/scalar/angle.py
+++ b/src/shapepy/scalar/angle.py
@@ -321,29 +321,4 @@ def to_angle(obj: object) -> Angle:
     return Angle.radians(obj)
 
 
-def is_angle(obj: object) -> bool:
-    """
-    Checks if the object is an instance of Angle
-
-    Parameters
-    ----------
-    obj : object
-        The object to check
-
-    Returns
-    -------
-    bool
-        True if the object is an instance of Angle, False otherwise
-
-    Example
-    -------
-    >>> is_angle(Angle.radians(1))
-    True
-    >>> is_angle(1.25)
-    False
-    """
-    return Is.instance(obj, Angle)
-
-
 To.angle = to_angle
-Is.angle = is_angle

--- a/tests/bool2d/test_empty_whole.py
+++ b/tests/bool2d/test_empty_whole.py
@@ -3,12 +3,14 @@ Tests related to 'EmptyShape' and 'WholeShape' which describes a empty set
 and the whole domain
 """
 
-from copy import copy
+from copy import copy, deepcopy
 
 import pytest
 
+from shapepy import move, rotate, scale
 from shapepy.bool2d.base import EmptyShape, WholeShape
 from shapepy.bool2d.primitive import Primitive
+from shapepy.scalar.angle import Angle
 
 
 @pytest.mark.order(24)
@@ -23,107 +25,160 @@ def test_begin():
     pass
 
 
-class TestBoolean:
-    """
-    Test boolean with special cases, a empty shape and whole domain
-    """
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_singleton():
+    assert EmptyShape() is EmptyShape()
+    assert WholeShape() is WholeShape()
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["test_begin"])
-    def test_begin(self):
-        pass
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_or(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert empty | empty is empty
-        assert empty | whole is whole
-        assert whole | empty is whole
-        assert whole | whole is whole
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_invert():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert ~empty is whole
+    assert ~whole is empty
+    assert ~(~empty) is empty
+    assert ~(~whole) is whole
 
-        assert empty + empty is empty
-        assert empty + whole is whole
-        assert whole + empty is whole
-        assert whole + whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_and(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert empty & empty is empty
-        assert empty & whole is empty
-        assert whole & empty is empty
-        assert whole & whole is whole
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton", "test_invert"])
+def test_neg():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert -empty is whole
+    assert -whole is empty
+    assert -(-empty) is empty
+    assert -(-whole) is whole
 
-        assert empty * empty is empty
-        assert empty * whole is empty
-        assert whole * empty is empty
-        assert whole * whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_xor(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert empty ^ empty is empty
-        assert empty ^ whole is whole
-        assert whole ^ empty is whole
-        assert whole ^ whole is empty
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_or():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty | empty is empty
+    assert empty | whole is whole
+    assert whole | empty is whole
+    assert whole | whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_sub(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert empty - empty is empty
-        assert empty - whole is empty
-        assert whole - empty is whole
-        assert whole - whole is empty
+    assert empty + empty is empty
+    assert empty + whole is whole
+    assert whole + empty is whole
+    assert whole + whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_bool(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert bool(empty) is False
-        assert bool(whole) is True
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_invert(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert ~empty is whole
-        assert ~whole is empty
-        assert ~(~empty) is empty
-        assert ~(~whole) is whole
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_and():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty & empty is empty
+    assert empty & whole is empty
+    assert whole & empty is empty
+    assert whole & whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(depends=["TestBoolean::test_begin"])
-    def test_copy(self):
-        empty = EmptyShape()
-        whole = WholeShape()
-        assert copy(empty) is empty
-        assert copy(whole) is whole
+    assert empty * empty is empty
+    assert empty * whole is empty
+    assert whole * empty is empty
+    assert whole * whole is whole
 
-    @pytest.mark.order(24)
-    @pytest.mark.dependency(
-        depends=[
-            "TestBoolean::test_begin",
-            "TestBoolean::test_or",
-            "TestBoolean::test_and",
-            "TestBoolean::test_xor",
-            "TestBoolean::test_sub",
-            "TestBoolean::test_bool",
-            "TestBoolean::test_invert",
-            "TestBoolean::test_copy",
-        ]
-    )
-    def test_end(self):
-        pass
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(
+    depends=["test_singleton", "test_or", "test_and", "test_invert"]
+)
+def test_xor():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty ^ empty is empty
+    assert empty ^ whole is whole
+    assert whole ^ empty is whole
+    assert whole ^ whole is empty
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(
+    depends=["test_singleton", "test_or", "test_and", "test_invert"]
+)
+def test_sub():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty - empty is empty
+    assert empty - whole is empty
+    assert whole - empty is whole
+    assert whole - whole is empty
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_bool():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert bool(empty) is False
+    assert bool(whole) is True
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_copy():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert copy(empty) is empty
+    assert copy(whole) is whole
+    assert deepcopy(empty) is empty
+    assert deepcopy(whole) is whole
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_move():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty.move((1, 0)) is empty
+    assert whole.move((1, 0)) is whole
+
+    assert move(empty, (1, 0)) is empty
+    assert move(whole, (1, 0)) is whole
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_scale():
+    empty = EmptyShape()
+    whole = WholeShape()
+    assert empty.scale((2, 1)) is empty
+    assert whole.scale((3, 2)) is whole
+
+    assert scale(empty, (2, 3)) is empty
+    assert scale(whole, (3, 2)) is whole
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_rotate():
+    empty = EmptyShape()
+    whole = WholeShape()
+    angle = Angle.degrees(30)
+    assert empty.rotate(angle) is empty
+    assert whole.rotate(angle) is whole
+
+    assert rotate(empty, angle) is empty
+    assert rotate(whole, angle) is whole
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_print():
+    empty = EmptyShape()
+    whole = WholeShape()
+
+    assert str(empty) == "EmptyShape"
+    assert str(whole) == "WholeShape"
+    assert isinstance(repr(empty), str)
+    assert isinstance(repr(whole), str)
 
 
 class TestBoolShape:
@@ -131,7 +186,19 @@ class TestBoolShape:
     @pytest.mark.dependency(
         depends=[
             "test_begin",
-            "TestBoolean::test_end",
+            "test_singleton",
+            "test_invert",
+            "test_neg",
+            "test_or",
+            "test_and",
+            "test_xor",
+            "test_sub",
+            "test_bool",
+            "test_copy",
+            "test_move",
+            "test_scale",
+            "test_rotate",
+            "test_print",
         ]
     )
     def test_begin(self):
@@ -230,7 +297,19 @@ class TestBoolShape:
 @pytest.mark.dependency(
     depends=[
         "test_begin",
-        "TestBoolean::test_end",
+        "test_singleton",
+        "test_invert",
+        "test_neg",
+        "test_or",
+        "test_and",
+        "test_xor",
+        "test_sub",
+        "test_bool",
+        "test_copy",
+        "test_move",
+        "test_scale",
+        "test_rotate",
+        "test_print",
         "TestBoolShape::test_end",
     ]
 )

--- a/tests/bool2d/test_shape.py
+++ b/tests/bool2d/test_shape.py
@@ -39,7 +39,7 @@ class TestIntegrate:
         width, height = 6, 10  # sides of rectangle
         nx, ny = 5, 5  # Max exponential
         rectangular = Primitive.square()
-        rectangular.scale(width, height)
+        rectangular.scale((width, height))
         for expx in range(nx):
             for expy in range(ny):
                 test = IntegrateJordan.polynomial(
@@ -67,7 +67,7 @@ class TestIntegrate:
         center = 7, -3  # Center of shape
         nx, ny = 5, 5  # Max exponential
         rectangular = Primitive.square()
-        rectangular.scale(width, height)
+        rectangular.scale((width, height))
         rectangular.move(center)
         for expx in range(nx):
             for expy in range(ny):
@@ -95,7 +95,7 @@ class TestIntegrate:
     def test_centered_rombo(self):
         width, height = 3, 5
         rombo = Primitive.regular_polygon(4)
-        rombo.scale(width, height)
+        rombo.scale((width, height))
         nx, ny = 5, 5
         for expx in range(nx):
             for expy in range(ny):

--- a/tests/bool2d/test_transform.py
+++ b/tests/bool2d/test_transform.py
@@ -1,0 +1,149 @@
+"""File to test the functions `move`, `scale` and `rotate`"""
+
+"""
+Tests related to 'EmptyShape' and 'WholeShape' which describes a empty set
+and the whole domain
+"""
+
+import pytest
+
+from shapepy.bool2d.primitive import Primitive
+from shapepy.bool2d.shape import ConnectedShape, DisjointShape
+from shapepy.geometry.box import Box
+from shapepy.scalar.angle import Angle
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(
+    depends=[
+        "tests/bool2d/test_primitive.py::test_end",
+        "tests/bool2d/test_contains.py::test_end",
+    ],
+    scope="session",
+)
+def test_begin():
+    pass
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_move_simple():
+    square = Primitive.square(2)
+    assert square.box() == Box((-1, -1), (1, 1))
+
+    square.move((1, 1))
+    assert square.box() == Box((0, 0), (2, 2))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_scale_simple():
+    square = Primitive.square(2)
+    assert square.box() == Box((-1, -1), (1, 1))
+
+    square.scale((3, 4))
+    assert square.box() == Box((-3, -4), (3, 4))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_rotate_simple():
+    square = Primitive.square(2)
+    assert square.box() == Box((-1, -1), (1, 1))
+
+    angle = Angle.degrees(90)
+    square.rotate(angle)
+    assert square.box() == Box((-1, -1), (1, 1))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_move_simple"])
+def test_move_connected():
+    small_square = Primitive.square(2)
+    big_square = Primitive.square(4)
+    connected = ConnectedShape([big_square, ~small_square])
+    assert connected.box() == Box((-2, -2), (2, 2))
+
+    connected.move((2, 2))
+    assert connected.box() == Box((0, 0), (4, 4))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_scale_simple"])
+def test_scale_connected():
+    small_square = Primitive.square(2)
+    big_square = Primitive.square(4)
+    connected = ConnectedShape([big_square, ~small_square])
+    assert connected.box() == Box((-2, -2), (2, 2))
+
+    connected.scale((3, 4))
+    assert connected.box() == Box((-6, -8), (6, 8))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_rotate_simple"])
+def test_rotate_connected():
+    small_square = Primitive.square(2)
+    big_square = Primitive.square(4)
+    connected = ConnectedShape([big_square, ~small_square])
+    assert connected.box() == Box((-2, -2), (2, 2))
+
+    angle = Angle.degrees(90)
+    connected.rotate(angle)
+    assert connected.box() == Box((-2, -2), (2, 2))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_move_simple"])
+def test_move_disjoint():
+    left_square = Primitive.square(2, (-2, 0))
+    right_square = Primitive.square(2, (2, 0))
+    disjoint = DisjointShape([left_square, right_square])
+    assert disjoint.box() == Box((-3, -1), (3, 1))
+
+    disjoint.move((2, 2))
+    assert disjoint.box() == Box((-1, 1), (5, 3))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_scale_simple"])
+def test_scale_disjoint():
+    left_square = Primitive.square(2, (-2, 0))
+    right_square = Primitive.square(2, (2, 0))
+    disjoint = DisjointShape([left_square, right_square])
+    assert disjoint.box() == Box((-3, -1), (3, 1))
+
+    disjoint.scale((3, 4))
+    assert disjoint.box() == Box((-9, -4), (9, 4))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_rotate_simple"])
+def test_rotate_disjoint():
+    left_square = Primitive.square(2, (-2, 0))
+    right_square = Primitive.square(2, (2, 0))
+    disjoint = DisjointShape([left_square, right_square])
+    assert disjoint.box() == Box((-3, -1), (3, 1))
+
+    angle = Angle.degrees(90)
+    disjoint.rotate(angle)
+    assert disjoint.box() == Box((-1, -3), (1, 3))
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(
+    depends=[
+        "test_begin",
+        "test_move_simple",
+        "test_scale_simple",
+        "test_rotate_simple",
+        "test_move_connected",
+        "test_scale_connected",
+        "test_rotate_connected",
+        "test_move_disjoint",
+        "test_scale_disjoint",
+        "test_rotate_disjoint",
+    ]
+)
+def test_end():
+    pass

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -10,6 +10,7 @@ import pytest
 from shapepy.geometry.factory import FactoryJordan
 from shapepy.geometry.integral import IntegrateJordan
 from shapepy.geometry.jordancurve import clean_jordan
+from shapepy.scalar.angle import Angle
 
 
 @pytest.mark.order(15)
@@ -19,6 +20,7 @@ from shapepy.geometry.jordancurve import clean_jordan
         "tests/geometry/test_box.py::test_all",
         "tests/geometry/test_segment.py::test_all",
         "tests/geometry/test_piecewise.py::test_all",
+        "tests/geometry/test_usegment.py::test_all",
     ],
     scope="session",
 )
@@ -252,7 +254,7 @@ class TestTransformationPolygon:
         good_rectangle = FactoryJordan.polygon(good_rectangle_pts)
         test_rectangle_pts = [(0, 0), (1, 0), (1, 1), (0, 1)]
         test_rectangle = FactoryJordan.polygon(test_rectangle_pts)
-        test_rectangle.scale(2, 3)
+        test_rectangle.scale((2, 3))
         assert test_rectangle == good_rectangle
 
     @pytest.mark.order(15)
@@ -271,9 +273,9 @@ class TestTransformationPolygon:
         test_square = FactoryJordan.polygon(test_square_pts)
 
         assert test_square == good_square
-        test_square.rotate(np.pi / 6)  # 30 degrees
+        test_square.rotate(Angle.radians(np.pi / 6))  # 30 degrees
         assert test_square != good_square
-        test_square.rotate(60, degrees=True)
+        test_square.rotate(Angle.degrees(60))
         assert test_square == good_square
 
     @pytest.mark.order(15)

--- a/tests/geometry/test_usegment.py
+++ b/tests/geometry/test_usegment.py
@@ -1,0 +1,100 @@
+"""
+This file contains tests functions to test the module polygon.py
+"""
+
+import pytest
+
+from shapepy.geometry.box import Box
+from shapepy.geometry.segment import Segment
+from shapepy.geometry.unparam import USegment
+from shapepy.scalar.angle import Angle
+
+
+@pytest.mark.order(14)
+@pytest.mark.dependency(
+    depends=[
+        "tests/geometry/test_segment.py::test_all",
+    ],
+    scope="session",
+)
+def test_begin():
+    pass
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_build():
+    segment = Segment([(0, 0), (1, 0), (0, 1)])
+    USegment(segment)
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_length():
+    segment = Segment([(0, 0), (3, 4)])
+    usegment = USegment(segment)
+    assert usegment.length == 5
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_box():
+    segment = Segment([(0, 0), (3, 4)])
+    usegment = USegment(segment)
+    assert usegment.box() == Box((0, 0), (3, 4))
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_move():
+    segment = Segment([(0, 0), (3, 4)])
+    usegment = USegment(segment)
+    usegment.move((1, 2))
+
+    good = Segment([(1, 2), (4, 6)])
+    assert usegment.parametrize() == good
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_scale():
+    segment = Segment([(0, 0), (3, 4)])
+    usegment = USegment(segment)
+    usegment.scale(4)
+
+    good = Segment([(0, 0), (12, 16)])
+    assert usegment.parametrize() == good
+
+
+@pytest.mark.order(14)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin"])
+def test_rotate():
+    segment = Segment([(0, 0), (3, 4)])
+    usegment = USegment(segment)
+    angle = Angle.degrees(90)
+    usegment.rotate(angle)
+
+    good = Segment([(0, 0), (-4, 3)])
+    assert usegment.parametrize() == good
+
+
+@pytest.mark.order(14)
+@pytest.mark.dependency(
+    depends=[
+        "test_begin",
+        "test_build",
+        "test_length",
+        "test_box",
+        "test_move",
+        "test_scale",
+        "test_rotate",
+    ]
+)
+def test_all():
+    pass


### PR DESCRIPTION
This PR touches the transformation functions of 2D objects, like `move`, `scale` and `rotate`.

* For Geometry:
    * `Point2D`
    * `Segment`
    * `USegment`
    * `PiecewiseCurve`
    * `JordanCurve` 
* For Bool2D objects
    * `SubSetR2`
    * `EmptyShape`
    * `WholeShape`
    * `SimpleShape`
    * `ConnectedShape`
    * `DisjointShape`

Also adds the generic method `move`, `scale` and `rotate` to easy access on the initial.
They create a copy of the instance and then moves that new instance.
```python
from shapepy import move, scale, rotate
```