### PR TITLE
feat: use analytics to compute winding number

### DIFF
--- a/src/shapepy/common.py
+++ b/src/shapepy/common.py
@@ -81,3 +81,10 @@ def clean(obj: Any) -> Any:
     Cleans the object, removing the unecessary data
     """
     return deepcopy(obj).clean()
+
+
+def derivate(obj: Any) -> Any:
+    """
+    Derivates the analytic function or the curve
+    """
+    return deepcopy(obj).derivate()

--- a/src/shapepy/geometry/intersection.py
+++ b/src/shapepy/geometry/intersection.py
@@ -190,6 +190,9 @@ class GeometricIntersectionCurves:
                 newparis.append((i, n + j))
         return GeometricIntersectionCurves(newcurves, newparis)
 
+    def __bool__(self):
+        return all(v == Empty() for v in self.all_subsets.values())
+
 
 def curve_and_curve(
     curvea: IGeometricCurve, curveb: IGeometricCurve

--- a/src/shapepy/geometry/piecewise.py
+++ b/src/shapepy/geometry/piecewise.py
@@ -9,7 +9,7 @@ from typing import Iterable, Tuple, Union
 
 from ..scalar.angle import Angle
 from ..scalar.reals import Real
-from ..tools import Is, To
+from ..tools import Is, To, vectorize
 from .base import IParametrizedCurve
 from .box import Box
 from .point import Point2D
@@ -143,6 +143,7 @@ class PiecewiseCurve(IParametrizedCurve):
         self.__knots = tuple(sorted(list(self.knots) + list(nodes)))
         self.__segments = tuple(newsegments)
 
+    @vectorize(1, 0)
     def __call__(self, node: float, derivate: int = 0) -> Point2D:
         index = self.span(node)
         if index is None:

--- a/tests/bool2d/test_shape.py
+++ b/tests/bool2d/test_shape.py
@@ -43,7 +43,7 @@ class TestIntegrate:
         for expx in range(nx):
             for expy in range(ny):
                 test = IntegrateJordan.polynomial(
-                    rectangular.jordans[0], expx, expy
+                    rectangular.jordan, expx, expy
                 )
                 if expx % 2 or expy % 2:
                     good = 0
@@ -72,7 +72,7 @@ class TestIntegrate:
         for expx in range(nx):
             for expy in range(ny):
                 test = IntegrateJordan.polynomial(
-                    rectangular.jordans[0], expx, expy
+                    rectangular.jordan, expx, expy
                 )
                 good = (center[0] + width / 2) ** (expx + 1) - (
                     center[0] - width / 2
@@ -99,7 +99,7 @@ class TestIntegrate:
         nx, ny = 5, 5
         for expx in range(nx):
             for expy in range(ny):
-                test = IntegrateJordan.polynomial(rombo.jordans[0], expx, expy)
+                test = IntegrateJordan.polynomial(rombo.jordan, expx, expy)
                 if expx % 2 or expy % 2:
                     good = 0
                 else:

--- a/tests/bool2d/test_transform.py
+++ b/tests/bool2d/test_transform.py
@@ -1,10 +1,5 @@
 """File to test the functions `move`, `scale` and `rotate`"""
 
-"""
-Tests related to 'EmptyShape' and 'WholeShape' which describes a empty set
-and the whole domain
-"""
-
 import pytest
 
 from shapepy.bool2d.primitive import Primitive

--- a/tests/geometry/test_integral.py
+++ b/tests/geometry/test_integral.py
@@ -1,13 +1,13 @@
 import math
 
-import numpy as np
 import pytest
 
-from shapepy.geometry.integral import IntegrateSegment
+from shapepy.geometry.factory import FactoryJordan
+from shapepy.geometry.integral import winding_number
 from shapepy.geometry.segment import Segment
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(15)
 @pytest.mark.dependency(
     depends=[
         "tests/analytic/test_derivate.py::test_all",
@@ -22,10 +22,10 @@ def test_begin():
     pass
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(15)
 @pytest.mark.timeout(10)
 @pytest.mark.dependency(depends=["test_begin"])
-def test_lenght():
+def test_segment_length():
     points = [(0, 0), (1, 0)]
     curve = Segment(points)
     assert abs(curve.length - 1) < 1e-9
@@ -36,94 +36,231 @@ def test_lenght():
 
     points = [(0, 1), (1, 0)]
     curve = Segment(points)
-    assert abs(curve.length - np.sqrt(2)) < 1e-9
+    assert abs(curve.length - math.sqrt(2)) < 1e-9
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(15)
 @pytest.mark.timeout(10)
-@pytest.mark.dependency(depends=["test_begin"])
-def test_winding_triangles():
-    curve = Segment([(1, 0), (2, 0)])
-    wind = IntegrateSegment.winding_number(curve)
-    assert wind == 0
+@pytest.mark.dependency(depends=["test_begin", "test_segment_length"])
+def test_jordan_length():
+    vertices = [(0, 0), (3, 0), (0, 4)]
+    jordan = FactoryJordan.polygon(vertices)
+    assert jordan.length == 3 + 4 + 5
 
-    curve = Segment([(1, 0), (1, 1)])
-    wind = IntegrateSegment.winding_number(curve)
-    assert abs(wind - 0.125) < 1e-9
-
-    curve = Segment([(1, 0), (0, 1)])
-    wind = IntegrateSegment.winding_number(curve)
-    assert abs(wind - 0.25) < 1e-9
-
-    curve = Segment([(1, 0), (-0.5, np.sqrt(3) / 2)])
-    wind = IntegrateSegment.winding_number(curve)
-    assert abs(3 * wind - 1) < 1e-9
+    vertices = [(0, 0), (0, 4), (3, 0)]
+    jordan = FactoryJordan.polygon(vertices)
+    assert jordan.length == 3 + 4 + 5
 
 
-@pytest.mark.order(14)
+@pytest.mark.order(15)
+@pytest.mark.timeout(10)
+@pytest.mark.dependency(depends=["test_begin", "test_jordan_length"])
+def test_area():
+    vertices = [(0, 0), (3, 0), (0, 4)]
+    jordan = FactoryJordan.polygon(vertices)
+    assert jordan.area == 6
+
+    vertices = [(0, 0), (0, 4), (3, 0)]
+    jordan = FactoryJordan.polygon(vertices)
+    assert jordan.area == -6
+
+
+class TestWinding:
+    """
+    Tests the respective position
+    """
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(depends=["test_begin", "test_area"])
+    def test_begin(self):
+        pass
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(
+        depends=[
+            "TestWinding::test_begin",
+        ]
+    )
+    def test_standard_square(self):
+        vertices = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
+        jordan = FactoryJordan.polygon(vertices)
+        assert jordan.length == 8
+        assert jordan.area == 4
+
+        interiors = {(0, 0)}
+        exteriors = {
+            (2, 1),
+            (2, 2),
+            (3, 3),
+            (-1, -2),
+        }
+        mid_edges = {
+            (1, 0),
+            (0, 1),
+            (-1, 0),
+            (0, -1),
+        }
+        corners = {
+            (-1, -1): 0.25,
+            (1, -1): 0.25,
+            (1, 1): 0.25,
+            (-1, 1): 0.25,
+        }
+        for point in interiors:
+            assert winding_number(jordan, point) == 1
+        for point in exteriors:
+            assert winding_number(jordan, point) == 0
+        for point in mid_edges:
+            assert winding_number(jordan, point) == 0.5
+        for point, wind in corners.items():
+            assert winding_number(jordan, point) == wind
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(
+        depends=[
+            "TestWinding::test_begin",
+            "TestWinding::test_standard_square",
+        ]
+    )
+    def test_inverted_square(self):
+        vertices = [(-1, -1), (-1, 1), (1, 1), (1, -1)]
+        jordan = FactoryJordan.polygon(vertices)
+        assert jordan.length == 8
+        assert jordan.area == -4
+
+        interiors = {
+            (2, 1),
+            (2, 2),
+            (3, 3),
+            (-1, -2),
+        }
+        exteriors = {(0, 0)}
+        mid_edges = {
+            (1, 0),
+            (0, 1),
+            (-1, 0),
+            (0, -1),
+        }
+        corners = {
+            (-1, -1): 0.75,
+            (1, -1): 0.75,
+            (1, 1): 0.75,
+            (-1, 1): 0.75,
+        }
+        for point in interiors:
+            assert winding_number(jordan, point) == 1
+        for point in exteriors:
+            assert winding_number(jordan, point) == 0
+        for point in mid_edges:
+            assert winding_number(jordan, point) == 0.5
+        for point, wind in corners.items():
+            assert winding_number(jordan, point) == wind
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(
+        depends=[
+            "TestWinding::test_begin",
+            "TestWinding::test_standard_square",
+            "TestWinding::test_inverted_square",
+        ]
+    )
+    def test_standard_triangle(self):
+        vertices = [(0, 0), (3, 0), (0, 3)]
+        jordan = FactoryJordan.polygon(vertices)
+        assert jordan.area == 9 / 2
+
+        interiors = {(1, 1)}
+        exteriors = {
+            (2, 2),
+            (3, 3),
+            (-1, -1),
+        }
+        mid_edges = {
+            (1, 0),
+            (2, 0),
+            (2, 1),
+            (1, 2),
+            (0, 2),
+            (0, 1),
+        }
+        corners = {
+            (0, 0): 0.25,
+            (3, 0): 0.125,
+            (0, 3): 0.125,
+        }
+        for point in interiors:
+            assert winding_number(jordan, point) == 1
+        for point in exteriors:
+            assert winding_number(jordan, point) == 0
+        for point in mid_edges:
+            assert winding_number(jordan, point) == 0.5
+        for point, wind in corners.items():
+            assert winding_number(jordan, point) == wind
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(
+        depends=[
+            "TestWinding::test_begin",
+            "TestWinding::test_inverted_square",
+            "TestWinding::test_standard_triangle",
+        ]
+    )
+    def test_inverted_triangle(self):
+        vertices = [(0, 0), (0, 3), (3, 0)]
+        jordan = FactoryJordan.polygon(vertices)
+        assert jordan.area == -9 / 2
+
+        interiors = {
+            (2, 2),
+            (3, 3),
+            (-1, -1),
+        }
+        exteriors = {(1, 1)}
+        mid_edges = {
+            (1, 0),
+            (2, 0),
+            (2, 1),
+            (1, 2),
+            (0, 2),
+            (0, 1),
+        }
+        corners = {
+            (0, 0): 0.75,
+            (3, 0): 0.875,
+            (0, 3): 0.875,
+        }
+        for point in interiors:
+            assert winding_number(jordan, point) == 1
+        for point in exteriors:
+            assert winding_number(jordan, point) == 0
+        for point in mid_edges:
+            assert winding_number(jordan, point) == 0.5
+        for point, wind in corners.items():
+            assert winding_number(jordan, point) == wind
+
+    @pytest.mark.order(15)
+    @pytest.mark.dependency(
+        depends=[
+            "TestWinding::test_begin",
+            "TestWinding::test_standard_square",
+            "TestWinding::test_inverted_square",
+            "TestWinding::test_standard_triangle",
+            "TestWinding::test_inverted_triangle",
+        ]
+    )
+    def test_all(self):
+        pass
+
+
+@pytest.mark.order(15)
 @pytest.mark.timeout(10)
 @pytest.mark.dependency(
     depends=[
         "test_begin",
-        "test_winding_triangles",
-    ]
-)
-def test_winding_unit_circle():
-    np.random.seed(0)
-
-    ntests = 1000
-    maxim = 0
-    for _ in range(ntests):
-        angle0 = np.random.uniform(0, 2 * np.pi)
-        good_wind = np.random.uniform(-0.5, 0.5)
-        angle1 = angle0 + 2 * np.pi * good_wind
-        point0 = (np.cos(angle0), np.sin(angle0))
-        point1 = (np.cos(angle1), np.sin(angle1))
-        curve = Segment([point0, point1])
-        test_wind = IntegrateSegment.winding_number(curve)
-        diff = abs(good_wind - test_wind)
-        maxim = max(maxim, diff)
-        assert abs(good_wind - test_wind) < 1e-9
-
-
-@pytest.mark.order(14)
-@pytest.mark.timeout(10)
-@pytest.mark.dependency(
-    depends=[
-        "test_begin",
-        "test_winding_triangles",
-        "test_winding_unit_circle",
-    ]
-)
-def test_winding_regular_polygon():
-    for nsides in range(3, 10):
-        angles = np.linspace(0, math.tau, nsides + 1)
-        ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-        pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
-        curves = tuple(Segment(pair) for pair in pairs)
-        for curve in curves:
-            wind = IntegrateSegment.winding_number(curve)
-            assert abs(nsides * wind - 1) < 1e-2
-
-    for nsides in range(3, 10):
-        angles = np.linspace(math.tau, 0, nsides + 1)
-        ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
-        pairs = zip(ctrlpoints[:-1], ctrlpoints[1:])
-        curves = tuple(Segment(pair) for pair in pairs)
-        for curve in curves:
-            wind = IntegrateSegment.winding_number(curve)
-            assert abs(nsides * wind + 1) < 1e-2
-
-
-@pytest.mark.order(14)
-@pytest.mark.timeout(10)
-@pytest.mark.dependency(
-    depends=[
-        "test_begin",
-        "test_lenght",
-        "test_winding_triangles",
-        "test_winding_unit_circle",
-        "test_winding_regular_polygon",
+        "test_segment_length",
+        "test_jordan_length",
+        "test_area",
+        "TestWinding::test_all",
     ]
 )
 def test_all():

--- a/tests/geometry/test_jordan_polygon.py
+++ b/tests/geometry/test_jordan_polygon.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from shapepy.geometry.factory import FactoryJordan
-from shapepy.geometry.integral import IntegrateJordan
+from shapepy.geometry.integral import winding_number
 from shapepy.geometry.jordancurve import clean_jordan
 from shapepy.scalar.angle import Angle
 
@@ -336,19 +336,21 @@ class TestIntegrateJordan:
     @pytest.mark.timeout(10)
     @pytest.mark.dependency(depends=["TestIntegrateJordan::test_begin"])
     def test_winding_regular_polygon(self):
+        # Counter clockwise
         for nsides in range(3, 10):
             angles = np.linspace(0, math.tau, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
             jordancurve = FactoryJordan.polygon(ctrlpoints)
-            wind = IntegrateJordan.winding_number(jordancurve)
+            wind = winding_number(jordancurve)
             assert abs(wind - 1) < 1e-9
 
+        # Clockwise
         for nsides in range(3, 10):
             angles = np.linspace(math.tau, 0, nsides + 1)
             ctrlpoints = np.vstack([np.cos(angles), np.sin(angles)]).T
             jordancurve = FactoryJordan.polygon(ctrlpoints)
-            wind = IntegrateJordan.winding_number(jordancurve)
-            assert abs(wind + 1) < 1e-9
+            wind = winding_number(jordancurve)
+            assert abs(wind - 0) < 1e-9
 
     @pytest.mark.order(15)
     @pytest.mark.timeout(10)


### PR DESCRIPTION
This PR reformulates the computation of `__contains__` for boolean 2D objects.
We now use the `xfunc` and `yfunc` from the `segment` to compute the `winding_number`.
Before we split the segments in many linear segments and then we computed the contribution of each subsegment to the total.

The `winding` method were added for the classes `SimpleShape`, `ConnectedShape` and `Disjoint` shape to verify if a point is inside the given shape. 