### PR TITLE
Feat: add __hash__ for SubSetR2 classes

### DIFF
--- a/src/shapepy/bool2d/base.py
+++ b/src/shapepy/bool2d/base.py
@@ -69,6 +69,10 @@ class SubSetR2:
         return str(self)
 
     @abstractmethod
+    def __hash__(self):
+        raise NotImplementedError
+
+    @abstractmethod
     def move(self, vector: Point2D) -> SubSetR2:
         """
         Moves/translate entire shape by an amount
@@ -187,6 +191,9 @@ class EmptyShape(SubSetR2):
     def __bool__(self) -> bool:
         return False
 
+    def __hash__(self):
+        return 0
+
     def move(self, _):
         return self
 
@@ -245,6 +252,9 @@ class WholeShape(SubSetR2):
 
     def __bool__(self) -> bool:
         return True
+
+    def __hash__(self):
+        return 1
 
     def move(self, _):
         return self

--- a/tests/bool2d/test_empty_whole.py
+++ b/tests/bool2d/test_empty_whole.py
@@ -17,7 +17,6 @@ from shapepy.scalar.angle import Angle
 @pytest.mark.dependency(
     depends=[
         "tests/bool2d/test_primitive.py::test_end",
-        "tests/bool2d/test_contains.py::test_end",
     ],
     scope="session",
 )
@@ -181,6 +180,25 @@ def test_print():
     assert isinstance(repr(whole), str)
 
 
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_hash():
+    assert hash(EmptyShape()) == 0
+    assert hash(WholeShape()) == 1
+
+
+@pytest.mark.order(24)
+@pytest.mark.dependency(depends=["test_singleton"])
+def test_contains():
+    empty = EmptyShape()
+    whole = WholeShape()
+
+    assert empty in empty
+    assert empty in whole
+    assert whole not in empty
+    assert whole in whole
+
+
 class TestBoolShape:
     @pytest.mark.order(24)
     @pytest.mark.dependency(
@@ -199,6 +217,8 @@ class TestBoolShape:
             "test_scale",
             "test_rotate",
             "test_print",
+            "test_hash",
+            "test_contains",
         ]
     )
     def test_begin(self):
@@ -310,6 +330,8 @@ class TestBoolShape:
         "test_scale",
         "test_rotate",
         "test_print",
+        "test_hash",
+        "test_contains",
         "TestBoolShape::test_end",
     ]
 )


### PR DESCRIPTION
Add `__hash__` for all the `SubSetR2` instances:

* `EmptyShape` -> `0`
* `WholeShape` -> `0`
* `SimpleShape` -> `shape.area`
* `ConnectedShape` -> `shape.area`
* `DisjointShape` -> `shape.area`