### PR TITLE
Config: Change default configuration of boolean cleans

### DIFF
--- a/src/shapepy/bool2d/base.py
+++ b/src/shapepy/bool2d/base.py
@@ -31,25 +31,19 @@ class SubSetR2:
     def __invert__(self) -> SubSetR2:
         """Invert shape"""
         result = Future.invert(self)
-        if Config.clean["inv"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["inv"] else result
 
     @debug("shapepy.bool2d.base")
     def __or__(self, other: SubSetR2) -> SubSetR2:
         """Union shapes"""
         result = Future.unite((self, other))
-        if Config.clean["or"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["or"] else result
 
     @debug("shapepy.bool2d.base")
     def __and__(self, other: SubSetR2) -> SubSetR2:
         """Intersection shapes"""
         result = Future.intersect((self, other))
-        if Config.clean["and"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["and"] else result
 
     @abstractmethod
     def __copy__(self) -> SubSetR2:
@@ -62,41 +56,31 @@ class SubSetR2:
     def __neg__(self) -> SubSetR2:
         """Invert the SubSetR2"""
         result = Future.invert(self)
-        if Config.clean["neg"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["neg"] else result
 
     @debug("shapepy.bool2d.base")
     def __add__(self, other: SubSetR2):
         """Union of SubSetR2"""
         result = Future.unite((self, other))
-        if Config.clean["add"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["add"] else result
 
     @debug("shapepy.bool2d.base")
     def __mul__(self, other: SubSetR2):
         """Intersection of SubSetR2"""
         result = Future.intersect((self, other))
-        if Config.clean["mul"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["mul"] else result
 
     @debug("shapepy.bool2d.base")
     def __sub__(self, other: SubSetR2):
         """Subtraction of SubSetR2"""
         result = Future.intersect((self, Future.invert(other)))
-        if Config.clean["sub"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["sub"] else result
 
     @debug("shapepy.bool2d.base")
     def __xor__(self, other: SubSetR2):
         """XOR of SubSetR2"""
         result = Future.xor((self, other))
-        if Config.clean["xor"]:
-            result = Future.clean(result)
-        return result
+        return Future.clean(result) if Config.clean["xor"] else result
 
     def __repr__(self) -> str:  # pragma: no cover
         return str(self)
@@ -343,7 +327,8 @@ class WholeShape(SubSetR2):
         return EmptyShape()
 
     def __xor__(self, other: SubSetR2) -> SubSetR2:
-        return ~Future.convert(other)
+        result = ~Future.convert(other)
+        return Future.clean(result) if Config.clean["xor"] else result
 
     def __contains__(self, other: SubSetR2) -> bool:
         return True
@@ -352,7 +337,8 @@ class WholeShape(SubSetR2):
         return "WholeShape"
 
     def __sub__(self, other: SubSetR2) -> SubSetR2:
-        return ~Future.convert(other)
+        result = ~Future.convert(other)
+        return Future.clean(result) if Config.clean["xor"] else result
 
     def __bool__(self) -> bool:
         return True

--- a/src/shapepy/bool2d/boolean.py
+++ b/src/shapepy/bool2d/boolean.py
@@ -164,7 +164,7 @@ def clean_bool2d_not(subset: LazyNot) -> SubSetR2:
     if Is.instance(inverted, SimpleShape):
         return SimpleShape(~inverted.jordan, True)
     if Is.instance(inverted, ConnectedShape):
-        return DisjointShape(~simple for simple in inverted.subshapes)
+        return DisjointShape((~s).clean() for s in inverted.subshapes)
     if Is.instance(inverted, DisjointShape):
         new_jordans = tuple(~jordan for jordan in inverted.jordans)
         return shape_from_jordans(new_jordans)

--- a/src/shapepy/bool2d/config.py
+++ b/src/shapepy/bool2d/config.py
@@ -9,22 +9,25 @@ class Config:
 
     clean = {
         "add": True,
-        "or": True,
+        "or": False,
         "xor": True,
-        "and": True,
+        "and": False,
         "sub": True,
         "mul": True,
         "neg": True,
-        "inv": True,
+        "inv": False,
     }
+
+    auto_clean = True
 
 
 @contextmanager
-def disable_auto_clean():
-    """Function that disables temporarily the auto clean"""
+def set_auto_clean(value: bool):
+    """Function that enables/disables temporarily the auto clean"""
+    value = bool(value)
     old = Config.clean.copy()
     for key in Config.clean:
-        Config.clean[key] = False
+        Config.clean[key] = value
     try:
         yield
     finally:

--- a/src/shapepy/bool2d/shape.py
+++ b/src/shapepy/bool2d/shape.py
@@ -136,7 +136,7 @@ class SimpleShape(SubSetR2):
             if Is.instance(other, SimpleShape):
                 return self.__contains_simple(other)
             if Is.instance(other, ConnectedShape):
-                return ~self in ~other
+                return -self in -other
             if Is.instance(other, DisjointShape):
                 return all(o in self for o in other.subshapes)
             return Is.instance(other, EmptyShape)
@@ -300,7 +300,7 @@ class ConnectedShape(SubSetR2):
     def subshapes(self, simples: Iterable[SimpleShape]):
         simples = frozenset(simples)
         if not all(Is.instance(simple, SimpleShape) for simple in simples):
-            raise TypeError
+            raise TypeError(f"Invalid typos: {tuple(map(type, simples))}")
         self.__subshapes = simples
 
     def __contains__(self, other) -> bool:
@@ -448,7 +448,7 @@ class DisjointShape(SubSetR2):
         if not all(
             Is.instance(sub, (SimpleShape, ConnectedShape)) for sub in values
         ):
-            raise ValueError
+            raise ValueError(f"Invalid typos: {tuple(map(type, values))}")
         self.__subshapes = values
 
     def move(self, vector: Point2D) -> JordanCurve:

--- a/src/shapepy/plot/plot.py
+++ b/src/shapepy/plot/plot.py
@@ -149,6 +149,7 @@ class ShapePloter:
         Plots a SubSetR2, which can be EmptyShape, WholeShape, Simple, etc
         """
         assert Is.instance(shape, SubSetR2)
+        shape = shape.clean()
         if Is.instance(shape, EmptyShape):
             return
         if Is.instance(shape, WholeShape):

--- a/tests/bool2d/test_bool_finite_intersect.py
+++ b/tests/bool2d/test_bool_finite_intersect.py
@@ -50,8 +50,7 @@ class TestIntersectionSimple:
         good_points += [(0, -1), (1, -2), (3, 0), (1, 2)]
         good_shape = Primitive.polygon(good_points)
 
-        test_shape = square0 | square1
-        assert test_shape == good_shape
+        assert square0 + square1 == good_shape
 
     @pytest.mark.order(42)
     @pytest.mark.timeout(40)
@@ -60,9 +59,8 @@ class TestIntersectionSimple:
         square0 = Primitive.regular_polygon(nsides=4, radius=2, center=(-1, 0))
         square1 = Primitive.regular_polygon(nsides=4, radius=2, center=(1, 0))
 
-        test = square0 & square1
         good = Primitive.regular_polygon(nsides=4, radius=1, center=(0, 0))
-        assert test == good
+        assert square0 * square1 == good
 
     @pytest.mark.order(42)
     @pytest.mark.timeout(40)

--- a/tests/bool2d/test_bool_no_intersect.py
+++ b/tests/bool2d/test_bool_no_intersect.py
@@ -6,6 +6,7 @@ Which are in fact positive shapes defined only by one jordan curve
 import pytest
 
 from shapepy.bool2d.base import EmptyShape, WholeShape
+from shapepy.bool2d.config import set_auto_clean
 from shapepy.bool2d.primitive import Primitive
 from shapepy.bool2d.shape import ConnectedShape, DisjointShape
 
@@ -46,14 +47,15 @@ class TestTwoCenteredSquares:
         assert square1.area > 0
         assert square2.area > 0
 
-        assert square1 | square2 == square2
-        assert square2 | square1 == square2
-        assert square1 | (~square2) == DisjointShape([square1, ~square2])
-        assert square2 | (~square1) is WholeShape()
-        assert (~square1) | square2 is WholeShape()
-        assert (~square2) | square1 == DisjointShape([square1, ~square2])
-        assert (~square1) | (~square2) == ~square1
-        assert (~square2) | (~square1) == ~square1
+        with set_auto_clean(True):
+            assert square1 | square2 == square2
+            assert square2 | square1 == square2
+            assert square1 | (~square2) == DisjointShape([square1, ~square2])
+            assert square2 | (~square1) is WholeShape()
+            assert (~square1) | square2 is WholeShape()
+            assert (~square2) | square1 == DisjointShape([square1, ~square2])
+            assert (~square1) | (~square2) == ~square1
+            assert (~square2) | (~square1) == ~square1
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -64,14 +66,15 @@ class TestTwoCenteredSquares:
         assert square1.area > 0
         assert square2.area > 0
 
-        assert square1 & square2 == square1
-        assert square2 & square1 == square1
-        assert square1 & (~square2) is EmptyShape()
-        assert square2 & (~square1) == ConnectedShape([square2, ~square1])
-        assert (~square1) & square2 == ConnectedShape([square2, ~square1])
-        assert (~square2) & square1 is EmptyShape()
-        assert (~square1) & (~square2) == ~square2
-        assert (~square2) & (~square1) == ~square2
+        with set_auto_clean(True):
+            assert square1 & square2 == square1
+            assert square2 & square1 == square1
+            assert square1 & (~square2) is EmptyShape()
+            assert square2 & (~square1) == ConnectedShape([square2, ~square1])
+            assert (~square1) & square2 == ConnectedShape([square2, ~square1])
+            assert (~square2) & square1 is EmptyShape()
+            assert (~square1) & (~square2) == ~square2
+            assert (~square2) & (~square1) == ~square2
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -83,12 +86,12 @@ class TestTwoCenteredSquares:
         assert square2.area > 0
 
         assert square1 - square2 is EmptyShape()
-        assert square2 - square1 == ConnectedShape([square2, ~square1])
+        assert square2 - square1 == ConnectedShape([square2, -square1])
         assert square1 - (~square2) == square1
         assert square2 - (~square1) == square1
-        assert (~square1) - square2 == ~square2
-        assert (~square2) - square1 == ~square2
-        assert (~square1) - (~square2) == ConnectedShape([square2, ~square1])
+        assert (~square1) - square2 == -square2
+        assert (~square2) - square1 == -square2
+        assert (~square1) - (~square2) == ConnectedShape([square2, -square1])
         assert (~square2) - (~square1) is EmptyShape()
 
     @pytest.mark.order(41)
@@ -100,14 +103,14 @@ class TestTwoCenteredSquares:
         assert square1.area > 0
         assert square2.area > 0
 
-        assert square1 ^ square2 == ConnectedShape([square2, ~square1])
-        assert square2 ^ square1 == ConnectedShape([square2, ~square1])
-        assert square1 ^ (~square2) == DisjointShape([square1, ~square2])
-        assert square2 ^ (~square1) == DisjointShape([square1, ~square2])
-        assert (~square1) ^ square2 == DisjointShape([square1, ~square2])
-        assert (~square2) ^ square1 == DisjointShape([square1, ~square2])
-        assert (~square1) ^ (~square2) == ConnectedShape([square2, ~square1])
-        assert (~square2) ^ (~square1) == ConnectedShape([square2, ~square1])
+        assert square1 ^ square2 == ConnectedShape([square2, -square1])
+        assert square2 ^ square1 == ConnectedShape([square2, -square1])
+        assert square1 ^ (~square2) == DisjointShape([square1, -square2])
+        assert square2 ^ (~square1) == DisjointShape([square1, -square2])
+        assert (~square1) ^ square2 == DisjointShape([square1, -square2])
+        assert (~square2) ^ square1 == DisjointShape([square1, -square2])
+        assert (~square1) ^ (~square2) == ConnectedShape([square2, -square1])
+        assert (~square2) ^ (~square1) == ConnectedShape([square2, -square1])
 
     @pytest.mark.order(41)
     @pytest.mark.dependency(
@@ -147,14 +150,14 @@ class TestTwoDisjointSquares:
         assert left.area > 0
         assert right.area > 0
 
-        assert left | right == DisjointShape([left, right])
-        assert right | left == DisjointShape([left, right])
-        assert left | (~right) == ~right
-        assert right | (~left) == ~left
-        assert (~left) | right == ~left
-        assert (~right) | left == ~right
-        assert (~left) | (~right) is WholeShape()
-        assert (~right) | (~left) is WholeShape()
+        assert left + right == DisjointShape([left, right])
+        assert right + left == DisjointShape([left, right])
+        assert left + (~right) == -right
+        assert right + (~left) == -left
+        assert (~left) + right == -left
+        assert (~right) + left == -right
+        assert (~left) + (~right) is WholeShape()
+        assert (~right) + (~left) is WholeShape()
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -165,14 +168,14 @@ class TestTwoDisjointSquares:
         assert left.area > 0
         assert right.area > 0
 
-        assert left & right is EmptyShape()
-        assert right & left is EmptyShape()
-        assert left & (~right) == left
-        assert right & (~left) == right
-        assert (~left) & right == right
-        assert (~right) & left == left
-        assert (~left) & (~right) == ConnectedShape([~left, ~right])
-        assert (~right) & (~left) == ConnectedShape([~left, ~right])
+        assert left * right is EmptyShape()
+        assert right * left is EmptyShape()
+        assert left * (~right) == left
+        assert right * (~left) == right
+        assert (~left) * right == right
+        assert (~right) * left == left
+        assert (~left) * (~right) == ConnectedShape([-left, -right])
+        assert (~right) * (~left) == ConnectedShape([-left, -right])
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -187,8 +190,8 @@ class TestTwoDisjointSquares:
         assert right - left == right
         assert left - (~right) is EmptyShape()
         assert right - (~left) is EmptyShape()
-        assert (~left) - right == ConnectedShape([~left, ~right])
-        assert (~right) - left == ConnectedShape([~left, ~right])
+        assert (~left) - right == ConnectedShape([-left, -right])
+        assert (~right) - left == ConnectedShape([-left, -right])
         assert (~left) - (~right) == right
         assert (~right) - (~left) == left
 
@@ -203,10 +206,10 @@ class TestTwoDisjointSquares:
 
         assert left ^ right == DisjointShape([left, right])
         assert right ^ left == DisjointShape([left, right])
-        assert left ^ (~right) == ConnectedShape([~left, ~right])
-        assert right ^ (~left) == ConnectedShape([~left, ~right])
-        assert (~left) ^ right == ConnectedShape([~left, ~right])
-        assert (~right) ^ left == ConnectedShape([~left, ~right])
+        assert left ^ (~right) == ConnectedShape([-left, -right])
+        assert right ^ (~left) == ConnectedShape([-left, -right])
+        assert (~left) ^ right == ConnectedShape([-left, -right])
+        assert (~right) ^ left == ConnectedShape([-left, -right])
         assert (~left) ^ (~right) == DisjointShape([left, right])
         assert (~right) ^ (~left) == DisjointShape([left, right])
 
@@ -254,14 +257,14 @@ class TestTwoDisjHollowSquares:
         assert left.area > 0
         assert right.area > 0
 
-        assert left | right == DisjointShape([left, right])
-        assert right | left == DisjointShape([left, right])
-        assert left | (~right) == ~right
-        assert right | (~left) == ~left
-        assert (~left) | right == ~left
-        assert (~right) | left == ~right
-        assert (~left) | (~right) is WholeShape()
-        assert (~right) | (~left) is WholeShape()
+        assert left + right == DisjointShape([left, right])
+        assert right + left == DisjointShape([left, right])
+        assert left + (~right) == -right
+        assert right + (~left) == -left
+        assert (~left) + right == -left
+        assert (~right) + left == -right
+        assert (~left) + (~right) is WholeShape()
+        assert (~right) + (~left) is WholeShape()
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -276,16 +279,16 @@ class TestTwoDisjHollowSquares:
         assert left.area > 0
         assert right.area > 0
 
-        assert left & right is EmptyShape()
-        assert right & left is EmptyShape()
-        assert left & (~right) == left
-        assert right & (~left) == right
-        assert (~left) & right == right
-        assert (~right) & left == left
-        external = ConnectedShape([~left_big, ~right_big])
+        assert left * right is EmptyShape()
+        assert right * left is EmptyShape()
+        assert left * (~right) == left
+        assert right * (~left) == right
+        assert (~left) * right == right
+        assert (~right) * left == left
+        external = ConnectedShape([-left_big, -right_big])
         good = DisjointShape([left_sma, right_sma, external])
-        assert (~left) & (~right) == good
-        assert (~right) & (~left) == good
+        assert (~left) * (~right) == good
+        assert (~right) * (~left) == good
 
     @pytest.mark.order(41)
     @pytest.mark.timeout(40)
@@ -304,10 +307,10 @@ class TestTwoDisjHollowSquares:
         assert right - left == right
         assert left - (~right) is EmptyShape()
         assert right - (~left) is EmptyShape()
-        external = ConnectedShape([~left_big, ~right_big])
+        external = ConnectedShape([-left_big, -right_big])
         good = DisjointShape([left_sma, right_sma, external])
-        assert (~left) & (~right) == good
-        assert (~right) & (~left) == good
+        assert (~left) * (~right) == good
+        assert (~right) * (~left) == good
         assert (~left) - (~right) == right
         assert (~right) - (~left) == left
 
@@ -326,7 +329,7 @@ class TestTwoDisjHollowSquares:
 
         assert left ^ right == DisjointShape([left, right])
         assert right ^ left == DisjointShape([left, right])
-        external = ConnectedShape([~left_big, ~right_big])
+        external = ConnectedShape([-left_big, -right_big])
         good = DisjointShape([left_sma, right_sma, external])
         assert left ^ (~right) == good
         assert right ^ (~left) == good

--- a/tests/bool2d/test_bool_overlap.py
+++ b/tests/bool2d/test_bool_overlap.py
@@ -5,7 +5,7 @@ This module tests when two shapes have common edges/segments
 import pytest
 
 from shapepy.bool2d.base import EmptyShape, WholeShape
-from shapepy.bool2d.config import disable_auto_clean
+from shapepy.bool2d.config import set_auto_clean
 from shapepy.bool2d.primitive import Primitive
 
 
@@ -73,7 +73,7 @@ class TestEqualSquare:
         assert square.area > 0
         assert square - square is EmptyShape()
         assert square - (~square) == square
-        assert (~square) - square == ~square
+        assert (~square) - square == -square
         assert (~square) - (~square) is EmptyShape()
 
     @pytest.mark.order(43)
@@ -169,7 +169,7 @@ class TestEqualHollowSquare:
         assert square.area > 0
         assert square - square is EmptyShape()
         assert square - (~square) == square
-        assert (~square) - square == ~square
+        assert (~square) - square == -square
         assert (~square) - (~square) is EmptyShape()
 
     @pytest.mark.order(43)
@@ -224,11 +224,10 @@ class TestTriangle:
         vertices1 = [(0, 0), (0, 1), (-1, 0)]
         triangle0 = Primitive.polygon(vertices0)
         triangle1 = Primitive.polygon(vertices1)
-        test = triangle0 | triangle1
 
         vertices = [(1, 0), (0, 1), (-1, 0)]
         good = Primitive.polygon(vertices)
-        assert test == good
+        assert triangle0 + triangle1 == good
 
     @pytest.mark.order(43)
     @pytest.mark.timeout(40)
@@ -243,11 +242,10 @@ class TestTriangle:
         vertices1 = [(0, 0), (1, 0), (0, 1)]
         triangle0 = Primitive.polygon(vertices0)
         triangle1 = Primitive.polygon(vertices1)
-        test = triangle0 & triangle1
 
         vertices = [(0, 0), (1, 0), (0, 1)]
         good = Primitive.polygon(vertices)
-        assert test == good
+        assert triangle0 * triangle1 == good
 
     @pytest.mark.order(43)
     @pytest.mark.skip(reason="Fails due to float precision on py3.11")
@@ -308,7 +306,7 @@ class TestDisabledClean:
         small = Primitive.square(side=1, center=(0, 0))
         left = Primitive.circle(radius=3, center=(-10, 0))
         right = Primitive.circle(radius=3, center=(10, 0))
-        with disable_auto_clean():
+        with set_auto_clean(False):
             shape = big - small | left ^ right
             assert shape | shape == shape
             assert shape | (~shape) is WholeShape()
@@ -328,7 +326,7 @@ class TestDisabledClean:
         small = Primitive.square(side=1, center=(0, 0))
         left = Primitive.circle(radius=3, center=(-10, 0))
         right = Primitive.circle(radius=3, center=(10, 0))
-        with disable_auto_clean():
+        with set_auto_clean(False):
             shape = big - small | left ^ right
             assert shape & shape == shape
             assert shape & (~shape) is EmptyShape()
@@ -348,7 +346,7 @@ class TestDisabledClean:
         small = Primitive.square(side=1, center=(0, 0))
         left = Primitive.circle(radius=3, center=(-10, 0))
         right = Primitive.circle(radius=3, center=(10, 0))
-        with disable_auto_clean():
+        with set_auto_clean(False):
             shape = big - small | left ^ right
             assert shape - shape is EmptyShape()
             assert shape - (~shape) == shape
@@ -370,7 +368,7 @@ class TestDisabledClean:
         small = Primitive.square(side=1, center=(0, 0))
         left = Primitive.circle(radius=3, center=(-10, 0))
         right = Primitive.circle(radius=3, center=(10, 0))
-        with disable_auto_clean():
+        with set_auto_clean(False):
             shape = big - small | left ^ right
             assert shape ^ shape is EmptyShape()
             assert shape ^ (~shape) is WholeShape()

--- a/tests/bool2d/test_contains.py
+++ b/tests/bool2d/test_contains.py
@@ -138,7 +138,7 @@ class TestObjectsInEmptyWhole:
 
         big_square = Primitive.square(side=2)
         small_square = Primitive.square(side=1)
-        shape = ConnectedShape([big_square, ~small_square])
+        shape = ConnectedShape([big_square, -small_square])
         assert shape not in empty
         assert shape in whole
 
@@ -382,15 +382,15 @@ class TestObjectsInSimple:
         assert ~(big_square.jordan) not in small_square
         assert ~(big_square.jordan) in big_square
 
-        assert small_square.jordan in (~small_square)
-        assert small_square.jordan not in (~big_square)
-        assert big_square.jordan in (~small_square)
-        assert big_square.jordan in (~big_square)
+        assert small_square.jordan in (-small_square)
+        assert small_square.jordan not in (-big_square)
+        assert big_square.jordan in (-small_square)
+        assert big_square.jordan in (-big_square)
 
-        assert ~(small_square.jordan) in (~small_square)
-        assert ~(small_square.jordan) not in (~big_square)
-        assert ~(big_square.jordan) in (~small_square)
-        assert ~(big_square.jordan) in (~big_square)
+        assert ~(small_square.jordan) in (-small_square)
+        assert ~(small_square.jordan) not in (-big_square)
+        assert ~(big_square.jordan) in (-small_square)
+        assert ~(big_square.jordan) in (-big_square)
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(
@@ -409,24 +409,24 @@ class TestObjectsInSimple:
         small_square = Primitive.square(side=2)
         assert small_square in big_square
         assert big_square not in small_square
-        assert (~small_square) not in big_square
-        assert (~big_square) not in small_square
-        assert small_square not in (~big_square)
-        assert big_square not in (~small_square)
-        assert (~small_square) not in (~big_square)
-        assert (~big_square) in (~small_square)
+        assert (-small_square) not in big_square
+        assert (-big_square) not in small_square
+        assert small_square not in (-big_square)
+        assert big_square not in (-small_square)
+        assert (-small_square) not in (-big_square)
+        assert (-big_square) in (-small_square)
 
         # Disjoint squares
         left = Primitive.square(side=2, center=(-3, 0))
         right = Primitive.square(side=2, center=(3, 0))
         assert left not in right
         assert right not in left
-        assert (~left) not in right
-        assert (~right) not in left
-        assert left in (~right)
-        assert right in (~left)
-        assert (~left) not in (~right)
-        assert (~right) not in (~left)
+        assert (-left) not in right
+        assert (-right) not in left
+        assert left in (-right)
+        assert right in (-left)
+        assert (-left) not in (-right)
+        assert (-right) not in (-left)
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(
@@ -443,12 +443,12 @@ class TestObjectsInSimple:
         # centered squares
         big_square = Primitive.square(side=4)
         small_square = Primitive.square(side=2)
-        connected = ConnectedShape([big_square, ~small_square])
+        connected = ConnectedShape([big_square, -small_square])
 
         assert connected not in small_square
         assert connected in big_square
-        assert connected in (~small_square)
-        assert connected not in (~big_square)
+        assert connected in (-small_square)
+        assert connected not in (-big_square)
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(
@@ -547,7 +547,7 @@ class TestObjectsInConnected:
     def test_point(self):
         big_square = Primitive.square(side=4)
         small_square = Primitive.square(side=2)
-        connected = ConnectedShape([big_square, ~small_square])
+        connected = ConnectedShape([big_square, -small_square])
 
         # Exterior points
         assert (0, 0) not in connected
@@ -584,7 +584,7 @@ class TestObjectsInConnected:
         small_jordan = small_square.jordan
         big_square = Primitive.square(side=4)
         big_jordan = big_square.jordan
-        connected = ConnectedShape([big_square, ~small_square])
+        connected = ConnectedShape([big_square, -small_square])
 
         assert small_jordan in connected
         assert small_jordan in connected
@@ -609,12 +609,12 @@ class TestObjectsInConnected:
     def test_simple(self):
         small_square = Primitive.square(side=2)
         big_square = Primitive.square(side=4)
-        connected = ConnectedShape([big_square, ~small_square])
+        connected = ConnectedShape([big_square, -small_square])
 
         assert small_square not in connected
         assert big_square not in connected
-        assert (~small_square) not in connected
-        assert (~big_square) not in connected
+        assert (-small_square) not in connected
+        assert (-big_square) not in connected
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(
@@ -630,12 +630,12 @@ class TestObjectsInConnected:
     def test_connected(self):
         small_square = Primitive.square(side=2)
         big_square = Primitive.square(side=4)
-        _ = ConnectedShape([big_square, ~small_square])
+        _ = ConnectedShape([big_square, -small_square])
 
-        assert (~small_square) in (~small_square)
-        assert (~big_square) in (~small_square)
-        assert (~small_square) not in (~big_square)
-        assert (~big_square) in (~big_square)
+        assert (-small_square) in (-small_square)
+        assert (-big_square) in (-small_square)
+        assert (-small_square) not in (-big_square)
+        assert (-big_square) in (-big_square)
 
     @pytest.mark.order(24)
     @pytest.mark.dependency(

--- a/tests/bool2d/test_density.py
+++ b/tests/bool2d/test_density.py
@@ -324,7 +324,7 @@ def test_simple_shape():
 def test_connected_shape():
     big = Primitive.square(side=6)
     small = Primitive.square(side=2)
-    shape = ConnectedShape([big, ~small])
+    shape = ConnectedShape([big, -small])
     # Corners
     points_density = {
         (1, 1): 0.75,

--- a/tests/bool2d/test_empty_whole.py
+++ b/tests/bool2d/test_empty_whole.py
@@ -271,15 +271,15 @@ class TestBoolShape:
 
         # XOR
         assert shape ^ empty == shape
-        assert shape ^ whole == ~shape
+        assert shape ^ whole == -shape
         assert empty ^ shape == shape
-        assert whole ^ shape == ~shape
+        assert whole ^ shape == -shape
 
         # SUB
         assert shape - empty == shape
         assert shape - whole is empty
         assert empty - shape is empty
-        assert whole - shape == ~shape
+        assert whole - shape == -shape
 
     @pytest.mark.order(21)
     @pytest.mark.timeout(40)
@@ -307,15 +307,15 @@ class TestBoolShape:
 
         # XOR
         assert shape ^ empty == shape
-        assert shape ^ whole == ~shape
+        assert shape ^ whole == -shape
         assert empty ^ shape == shape
-        assert whole ^ shape == ~shape
+        assert whole ^ shape == -shape
 
         # SUB
         assert shape - empty == shape
         assert shape - whole is empty
         assert empty - shape is empty
-        assert whole - shape == ~shape
+        assert whole - shape == -shape
 
     @pytest.mark.order(21)
     @pytest.mark.timeout(40)

--- a/tests/bool2d/test_transform.py
+++ b/tests/bool2d/test_transform.py
@@ -56,7 +56,7 @@ def test_rotate_simple():
 def test_move_connected():
     small_square = Primitive.square(2)
     big_square = Primitive.square(4)
-    connected = ConnectedShape([big_square, ~small_square])
+    connected = ConnectedShape([big_square, -small_square])
     assert connected.box() == Box((-2, -2), (2, 2))
 
     connected.move((2, 2))
@@ -68,7 +68,7 @@ def test_move_connected():
 def test_scale_connected():
     small_square = Primitive.square(2)
     big_square = Primitive.square(4)
-    connected = ConnectedShape([big_square, ~small_square])
+    connected = ConnectedShape([big_square, -small_square])
     assert connected.box() == Box((-2, -2), (2, 2))
 
     connected.scale((3, 4))
@@ -80,7 +80,7 @@ def test_scale_connected():
 def test_rotate_connected():
     small_square = Primitive.square(2)
     big_square = Primitive.square(4)
-    connected = ConnectedShape([big_square, ~small_square])
+    connected = ConnectedShape([big_square, -small_square])
     assert connected.box() == Box((-2, -2), (2, 2))
 
     angle = degrees(90)


### PR DESCRIPTION
This PR relates to #63

This changes the default configurations when doing boolean operations.

So far every boolean operations call `clean`

This PR makes the operations `~`, `&` and `|` not  call the `clean` so it keeps as Lazy Operators